### PR TITLE
mask the api key parameter in directoryinsights app

### DIFF
--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -4,11 +4,11 @@ Transform: AWS::Serverless-2016-10-31
 Parameters:
   JumpCloudApiKey:
     Type: String
+    NoEcho: true
     AllowedPattern: \b[a-z0-9]{40}\b
   IncrementType:
     Type: String
     Default: day
-    NoEcho: true
     AllowedValues:
       - minute
       - minutes

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -8,6 +8,7 @@ Parameters:
   IncrementType:
     Type: String
     Default: day
+    NoEcho: true
     AllowedValues:
       - minute
       - minutes


### PR DESCRIPTION
If you set the NoEcho attribute to true, CloudFormation returns the parameter value masked as asterisks (*****) for any calls that describe the stack or stack events