### PR TITLE
Allow service filtering in DI app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/AWS/DirectoryInsights/CHANGELOG.md
+++ b/AWS/DirectoryInsights/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the AWS Directory Insights Serverless App will be documen
 
 - Ability to filter available services instead of querying all directory insights data.
   - Service can be set to query any of: "directory, radius, sso, systems, ldap, mdm" instead of the default "all" services
+- CloudWatch will now log for each service, notating when no results are found as NoResults_SERVICENAME
 
 ## [1.1.0] - 2020-08-11
 

--- a/AWS/DirectoryInsights/CHANGELOG.md
+++ b/AWS/DirectoryInsights/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the AWS Directory Insights Serverless App will be documented in this file.
+
+## [1.2.0] - 2022-01-12
+
+### Added
+
+- Ability to filter available services instead of querying all directory insights data.
+  - Service can be set to query any of: "directory, radius, sso, systems, ldap, mdm" instead of the default "all" services
+
+## [1.1.0] - 2020-08-11
+
+### Added
+
+- OrgID as an optional parameter
+
+## [1.0.0] - 2020-07-31
+
+### Added
+
+- Initial release of the JumpCloud AWS Directory Insights Serverless App

--- a/AWS/DirectoryInsights/README.md
+++ b/AWS/DirectoryInsights/README.md
@@ -11,7 +11,6 @@ _Note: This document assumes the use of Python 3+_
   - [Package and Deploy the Application](#package-and-deploy-the-application)
     - [Packaging the Application](#packaging-the-application)
     - [Deploying the Application](#deploying-the-application)
-    - [Alternative: Publish the Application](#alternative-publish-the-application)
 
 ## Pre-requisites
 - [Your JumpCloud API key](https://docs.jumpcloud.com/2.0/authentication-and-authorization/authentication-and-authorization-overview)
@@ -84,7 +83,7 @@ Using the AWS CLI, you can [deploy](https://docs.aws.amazon.com/cli/latest/refer
 ~/jc-directoryinsights$ aws cloudformation deploy --template-file ./packaged.yaml --stack-name <YOUR STACK NAME> --parameter-overrides JumpCloudApiKey=<API KEY> IncrementType=<INCREMENT TYPE> IncrementAmount=<INCREMENT AMOUNT> Service=<SERVICES> --capabilities CAPABILITY_IAM
 ```
 _Note: IncrementType accepts "minute", "minutes", "hour", "hours", "day", and "days". Use the singular if the IncrementAmount is "1". <br>
-Service accepts a comma-delimited list of services to log. Available services are the following: directory,radius,sso,systems,ldap,mdm_
+Service accepts a comma-delimited list of services to log. To select all services, set the Service parameter to "all". To limit data to a specific service set the Service parameter to any of the following: directory,radius,sso,systems,ldap,mdm.
 </details>
 
 <details>

--- a/AWS/DirectoryInsights/README.md
+++ b/AWS/DirectoryInsights/README.md
@@ -1,5 +1,5 @@
 # Gather JumpCloud Directory Insights Data with an AWS Serverless Application
-_This document will walk a JumpCloud Administrator through packaging and deploying this Serverless Application manually. This workflow is intended for those who need to make modifications to the code or tie this solution into other AWS resources. If you would simply like to deploy this Serverless Application as-is, you can do so from the Serverless Application Repository \<placeholder for link when it is offically published\>_
+_This document will walk a JumpCloud Administrator through packaging and deploying this Serverless Application manually. This workflow is intended for those who need to make modifications to the code or tie this solution into other AWS resources. If you would simply like to deploy this Serverless Application as-is, you can do so from the [Serverless Application Repository](https://serverlessrepo.aws.amazon.com/applications/us-east-2/339347137473/JumpCloud-DirectoryInsights)_
 
 _Note: This document assumes the use of Python 3+_
 ## Table of Contents
@@ -45,7 +45,7 @@ _Note: This document assumes the use of Python 3+_
   
 ## Create Python Script
 
-Create a directory to store your Serverless Application and any dependencies required. In the root of that directory create your [Python Script](https://github.com/TheJumpCloud/support/blob/SA-1258-DI-Serverless/AWS/Serverless/DirectoryInsights/get-jcdirectoryinsights.py).
+Create a directory to store your Serverless Application and any dependencies required. In the root of that directory create your [Python Script](https://github.com/TheJumpCloud/JumpCloud-Serverless/blob/master/AWS/DirectoryInsights/get-jcdirectoryinsights.py).
 
 This Application requires `boto3`, and `requests`. Install these dependencies using pip3. Within the directory you created, run the following commands to install the dependencies within the directory.
 ```bash
@@ -76,15 +76,19 @@ _Note: Provide the name of the S3 bucket that you created for packaging and stor
 
 
 ### Deploying the Application
+<details>
+<summary>AWS CLI</summary>
 
 Using the AWS CLI, you can [deploy](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/deploy/index.html) your template directly from your terminal.
 ```
-~/jc-directoryinsights$ aws cloudformation deploy --template-file ./packaged.yaml --stack-name <YOUR STACK NAME> --parameter-overrides JumpCloudApiKey=<API KEY> IncrementType=<INCREMENT TYPE> IncrementAmount=<INCREMENT AMOUNT>
+~/jc-directoryinsights$ aws cloudformation deploy --template-file ./packaged.yaml --stack-name <YOUR STACK NAME> --parameter-overrides JumpCloudApiKey=<API KEY> IncrementType=<INCREMENT TYPE> IncrementAmount=<INCREMENT AMOUNT> Service=<SERVICES> --capabilities CAPABILITY_IAM
 ```
-_Note: IncrementType accepts "minute", "minutes", "hour", "hours", "day", and "days". Use the singular if the IncrementAmount is "1"._
+_Note: IncrementType accepts "minute", "minutes", "hour", "hours", "day", and "days". Use the singular if the IncrementAmount is "1". <br>
+Service accepts a comma-delimited list of services to log. Available services are the following: directory,radius,sso,systems,ldap,mdm_
+</details>
 
-### Alternative: Publish the Application
-
+<details>
+<summary>Deploy Alternative: Privately Publish the Application</summary>
 Rather than deploying your Application from the CLI, you can also publish your application so that it is viewable via the [Severless Application Repository](https://console.aws.amazon.com/serverlessrepo/). By default, published applications are "Private" so they will not be publicly available until set otherwise.
 
 Using the AWS SAM CLI, publish your application to the Serverless Applications Repository.
@@ -92,3 +96,4 @@ Using the AWS SAM CLI, publish your application to the Serverless Applications R
 ~/jc-directorys$ sam publish --template packaged.yaml --region <REGION>
 ```
 Once you have published your Application to the [Severless Application Repository](https://console.aws.amazon.com/serverlessrepo/), you can find and deploy your application from the Private Applications tab.
+</details>

--- a/AWS/DirectoryInsights/ServerlessRepository/README.md
+++ b/AWS/DirectoryInsights/ServerlessRepository/README.md
@@ -10,6 +10,8 @@ This application will allow you to export your JumpCloud Organization's Director
   - Together these parameters will form the cadence at which this application exports your JumpCloud Directory Insights data. _Note: If your IncrementAmount is 1, please use the singular word for IncrementType_
 - JumpCloudApiKey
   - Your [JumpCloud API key](https://docs.jumpcloud.com/2.0/authentication-and-authorization/authentication-and-authorization-overview) will be safely stored in AWS Secrets Manager.
+- Service
+  - Here is where you can pick and choose which services you would like to collect the logging for. You can mix and match or choose all of them!
 
 ### What This Application Does
 

--- a/AWS/DirectoryInsights/get-jcdirectoryinsights.py
+++ b/AWS/DirectoryInsights/get-jcdirectoryinsights.py
@@ -12,6 +12,7 @@ def get_secret(secret_name):
     return secret
 
 def jc_directoryinsights(event, context):
+    #TODO: Add service param
     try:
         jcapikeyarn = os.environ['JcApiKeyArn']
         incrementType = os.environ['incrementType']
@@ -37,7 +38,7 @@ def jc_directoryinsights(event, context):
     end_date = now.isoformat("T") + "Z"
 
     outfileName = "jc_directoryinsights_" + start_date + "_" + end_date + ".json.gz"
-
+    #TODO: Loop through list of services and concat response bodies into singular file
     url = "https://api.jumpcloud.com/insights/directory/v1/events"
 
     body = {
@@ -62,6 +63,7 @@ def jc_directoryinsights(event, context):
         raise Exception(e)
     responseBody = json.loads(response.text)
 
+    #TODO: Add service name to MetricName, leave in loop, adjust return
     if response.text.strip() == "[]":
         cloudwatch = boto3.client('cloudwatch')
         metric = cloudwatch.put_metric_data(
@@ -97,6 +99,8 @@ def jc_directoryinsights(event, context):
             raise Exception(e)
         responseBody = json.loads(response.text)
         data = data + responseBody
+    
+    
     try:    
         gzOutfile = gzip.GzipFile(filename="/tmp/" + outfileName, mode="w", compresslevel=9)
         gzOutfile.write(json.dumps(data, indent=2).encode("UTF-8"))

--- a/AWS/DirectoryInsights/get-jcdirectoryinsights.py
+++ b/AWS/DirectoryInsights/get-jcdirectoryinsights.py
@@ -108,7 +108,7 @@ def jc_directoryinsights(event, context):
 
         finalData += data
     
-    if '[]' in finalData:
+    if len(finalData) == 0:
         return
     
     finalData.sort(key = lambda x:x['timestamp'], reverse=True)

--- a/AWS/DirectoryInsights/get-jcdirectoryinsights.py
+++ b/AWS/DirectoryInsights/get-jcdirectoryinsights.py
@@ -108,6 +108,9 @@ def jc_directoryinsights(event, context):
 
         finalData += data
     
+    if '[]' in finalData:
+        return
+    
     finalData.sort(key = lambda x:x['timestamp'], reverse=True)
 
     try:    

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -27,7 +27,7 @@ Parameters:
   Service:
     Type: CommaDelimitedList
     Default: "all"
-    Description: 'Comma-delimited list of desired services to log. Available services: "directory","radius","sso","systems","ldap","mdm". Default value is "all"'
+    Description: 'Comma-delimited list of desired services to log. Available services: directory,radius,sso,systems,ldap,mdm. Default value is "all"'
 
 Conditions:
   isSingular: !Equals [!Ref "IncrementAmount", 1]

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -25,7 +25,7 @@ Parameters:
     Default: ''
     Description: OPTIONAL - This parameter can be used to allow MTP Admins to select which Organization they would like to collect Directory Insights data for.
   Service:
-    Type: CommaDelimitedList
+    Type: String
     Default: "all"
     Description: 'Comma-delimited list of desired services to log. Available services: directory,radius,sso,systems,ldap,mdm. Default value is "all"'
 

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -27,7 +27,7 @@ Parameters:
   Service:
     Type: CommaDelimitedList
     Default: "all"
-    Description: 'Comma-delimited list of desired services to filter. Available services: "directory","radius","sso","systems","ldap","mdm". Default value is "all"'
+    Description: 'Comma-delimited list of desired services to log. Available services: "directory","radius","sso","systems","ldap","mdm". Default value is "all"'
 
 Conditions:
   isSingular: !Equals [!Ref "IncrementAmount", 1]

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -24,6 +24,10 @@ Parameters:
     Type: String
     Default: ''
     Description: OPTIONAL - This parameter can be used to allow MTP Admins to select which Organization they would like to collect Directory Insights data for.
+  Service:
+    Type: CommaDelimitedList
+    Default: "all"
+    Description: 'Comma-delimited list of desired services to filter. Available services: "directory","radius","sso","systems","ldap","mdm". Default value is "all"'
 
 Conditions:
   isSingular: !Equals [!Ref "IncrementAmount", 1]
@@ -123,6 +127,7 @@ Resources:
           JcApiKeyArn: !Ref JcApiKey
           incrementType: !Sub ${IncrementType}
           incrementAmount: !Sub ${IncrementAmount}
+          service: !Sub ${Service}
           BucketName: !Ref DirectoryInsightsBucket
           OrgId: !Sub ${OrganizationID}
       Events:

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -37,7 +37,7 @@ Metadata:
     Name: JumpCloud-DirectoryInsights
     Description: This Serverless Application can be used to collect your JumpCloud Directory Insights data at a regular interval.
     Author: JumpCloud Solutions Architecture
-    SemanticVersion: 1.1.0
+    SemanticVersion: 1.2.0
     HomePageUrl: https://git.io/JJlrZ
     SourceCodeUrl: https://git.io/JJiMo
     LicenseUrl: LICENSE


### PR DESCRIPTION
## Issues
* [SA-2142](https://jumpcloud.atlassian.net/browse/SA-2142) - DI AWS S3 Serverless Application data can't be filtered

## What does this solve?
This will allow admins to explicitly filter services, allowing for more precise logging and reduced clutter for the admin to manually filter through. This will also reduce the overall size of the files generated as well, which is a cost saver for the admin

## Is there anything particularly tricky?
No

## How should this be tested?
Privately deploy the application and select which services you would like to log. Generate Directory Insights events and ensure that the correct services are being properly collected. If no services are explicitly set, it will default to all. If services are explicitly set along with 'all' an error will be thrown.

## Screenshots
![image](https://user-images.githubusercontent.com/89030113/149225968-2b2f15a5-1ae3-4eca-9d5e-37340b1bd0c1.png)