### PR TITLE
Sa 2458 gcp di app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+/venv

--- a/GCP/DirectoryInsights/.gcloudignore
+++ b/GCP/DirectoryInsights/.gcloudignore
@@ -1,0 +1,2 @@
+/venv
+*.yaml

--- a/GCP/DirectoryInsights/CHANGELOG.md
+++ b/GCP/DirectoryInsights/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [1.0.0] - 2022-03-31
+
+### Added
+
+- Initial release of the JumpCloud GCP Directory Insights Serverless App

--- a/GCP/DirectoryInsights/LICENSE
+++ b/GCP/DirectoryInsights/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 TheJumpCloud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -1,7 +1,7 @@
 # Gather JumpCloud Directory Insights Data with GCP Services
-_This document will walk a JumpCloud Administrator through deploying this Serverless Application to GCP. 
+_This document will walk a JumpCloud Administrator through deploying this Serverless Application to GCP._
 
-_Note: This document assumes the use of Python 3.9
+_Note: This document assumes the use of Python 3.9_
 ## Table of Contents
 - [Gather JumpCloud Directory Insights Data with an GCP](#gather-jumpcloud-directory-insights-data-with-gcp-services)
   - [Table of Contents](#table-of-contents)
@@ -19,7 +19,8 @@ _Note: This document assumes the use of Python 3.9
     - Cloud Scheduler = Enabled
     - Secret Manager = Enabled
   - Cloud Build Service account email: admin access to services above
-  - JumpCloud administrator will need Cloud 
+- JumpCloud administrator will need `Cloud Build Editor` role with their GCP account
+- Cloud Functions Invoker service account
   
 ## Create Directory to Store Directory Insights Files
 
@@ -40,10 +41,10 @@ GCloud CLI
 
 Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/gcloud/reference/builds/submit) directly from the project directory
 ```bash
-~/DirectoryInsights$ gcloud build submit
+~/DirectoryInsights$ gcloud builds submit
 ```
-_Note: `gcloud build submit` default config is "cloudbuild.yaml" which is why we do not need to specify `--config=config.yaml` tag
-_Note: `.gcloudignore` file excludes unwanted files/folders from getting push in the deploy process
+_Note: `gcloud build submit` default config is "cloudbuild.yaml" which is why we do not need to specify `--config=config.yaml` tag_
+_Note: `.gcloudignore` file excludes unwanted files/folders from getting push in the deploy process_
 
 
 

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -1,0 +1,47 @@
+# Gather JumpCloud Directory Insights Data with an AWS Serverless Application
+_This document will walk a JumpCloud Administrator through packaging and deploying this Serverless Application manually. This workflow is intended for those who need to make modifications to the code or tie this solution into other AWS resources. If you would simply like to deploy this Serverless Application as-is, you can do so from the [Serverless Application Repository](https://serverlessrepo.aws.amazon.com/applications/us-east-2/339347137473/JumpCloud-DirectoryInsights)_
+
+_Note: This document assumes the use of Python 3+_
+## Table of Contents
+- [Gather JumpCloud Directory Insights Data with an AWS Serverless Application](#gather-jumpcloud-directory-insights-data-with-an-aws-serverless-application)
+  - [Table of Contents](#table-of-contents)
+  - [Pre-requisites](#pre-requisites)
+  - [Create Directory](#create-directory-to-store-directory-insights-files)
+  - [Edit cloudbuild.yaml](#edit-cloudbuildyaml)
+  - [Deploying the Application](#deploying-the-application)
+
+## Pre-requisites
+- [Your JumpCloud API key](https://docs.jumpcloud.com/2.0/authentication-and-authorization/authentication-and-authorization-overview)
+- [GCLOUD CLI installed](https://cloud.google.com/sdk/docs/install)
+- [Google Cloud Build](https://cloud.google.com/build/docs/securing-builds/configure-access-for-cloud-build-service-account)
+  - Permissions and access to create:
+    - Cloud Functions = Enabled
+    - Cloud Scheduler = Enabled
+    - Secret Manager = Enabled
+    - Cloud Build Service account email: admin access to services above
+  
+## Create Directory to Store Directory Insights Files
+
+Create a directory to store your Serverless Application and any dependencies required. In the root of that directory add [Directory Insights Files](https://github.com/TheJumpCloud/JumpCloud-Serverless/blob/master/GCP/DirectoryInsights/).
+Install the dependencies in requirements.txt file
+```bash
+~/DirectoryInsights$ pip install -r requirements.txt
+```
+
+## Edit CloudBuild.yaml
+
+In the root directory, edit cloudbuid.yaml file `substitutions` variable values with the necessary credentials
+
+
+## Deploying the Application
+
+<summary>GCloud CLI</summary>
+
+Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/gcloud/reference/builds/submit) directly from the project directory
+```bash
+~/DirectoryInsights$ gcloud build submit
+```
+_Note: `gcloud build submit` default config is "cloudbuild.yaml" which is why we do not need to specify `--config=config.yaml` tag
+
+
+

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -1,9 +1,9 @@
 # Gather JumpCloud Directory Insights Data with GCP Services
-_This document will walk a JumpCloud Administrator through deploying this Serverless Application manually. 
+_This document will walk a JumpCloud Administrator through deploying this Serverless Application to GCP. 
 
 _Note: This document assumes the use of Python 3.9
 ## Table of Contents
-- [Gather JumpCloud Directory Insights Data with an AWS Serverless Application](#gather-jumpcloud-directory-insights-data-with-an-aws-serverless-application)
+- [Gather JumpCloud Directory Insights Data with an GCP](#gather-jumpcloud-directory-insights-data-with-gcp-services)
   - [Table of Contents](#table-of-contents)
   - [Pre-requisites](#pre-requisites)
   - [Create Directory](#create-directory-to-store-directory-insights-files)
@@ -19,6 +19,7 @@ _Note: This document assumes the use of Python 3.9
     - Cloud Scheduler = Enabled
     - Secret Manager = Enabled
   - Cloud Build Service account email: admin access to services above
+  - JumpCloud administrator will need Cloud 
   
 ## Create Directory to Store Directory Insights Files
 
@@ -42,6 +43,7 @@ Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/
 ~/DirectoryInsights$ gcloud build submit
 ```
 _Note: `gcloud build submit` default config is "cloudbuild.yaml" which is why we do not need to specify `--config=config.yaml` tag
+_Note: `.gcloudignore` file excludes unwanted files/folders from getting push in the deploy process
 
 
 

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -34,7 +34,6 @@ Install the dependencies in requirements.txt file
 
 In the root directory, edit cloudbuid.yaml file `substitutions` variable values with the necessary credentials
 
-
 ## Deploying the Application
 
 GCloud CLI

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -1,7 +1,7 @@
-# Gather JumpCloud Directory Insights Data with an AWS Serverless Application
-_This document will walk a JumpCloud Administrator through packaging and deploying this Serverless Application manually. This workflow is intended for those who need to make modifications to the code or tie this solution into other AWS resources. If you would simply like to deploy this Serverless Application as-is, you can do so from the [Serverless Application Repository](https://serverlessrepo.aws.amazon.com/applications/us-east-2/339347137473/JumpCloud-DirectoryInsights)_
+# Gather JumpCloud Directory Insights Data with GCP Services
+_This document will walk a JumpCloud Administrator through deploying this Serverless Application manually. 
 
-_Note: This document assumes the use of Python 3+_
+_Note: This document assumes the use of Python 3.9
 ## Table of Contents
 - [Gather JumpCloud Directory Insights Data with an AWS Serverless Application](#gather-jumpcloud-directory-insights-data-with-an-aws-serverless-application)
   - [Table of Contents](#table-of-contents)
@@ -14,11 +14,11 @@ _Note: This document assumes the use of Python 3+_
 - [Your JumpCloud API key](https://docs.jumpcloud.com/2.0/authentication-and-authorization/authentication-and-authorization-overview)
 - [GCLOUD CLI installed](https://cloud.google.com/sdk/docs/install)
 - [Google Cloud Build](https://cloud.google.com/build/docs/securing-builds/configure-access-for-cloud-build-service-account)
-  - Permissions and access to create:
+  - Permissions:
     - Cloud Functions = Enabled
     - Cloud Scheduler = Enabled
     - Secret Manager = Enabled
-    - Cloud Build Service account email: admin access to services above
+  - Cloud Build Service account email: admin access to services above
   
 ## Create Directory to Store Directory Insights Files
 
@@ -35,7 +35,7 @@ In the root directory, edit cloudbuid.yaml file `substitutions` variable values 
 
 ## Deploying the Application
 
-<summary>GCloud CLI</summary>
+GCloud CLI
 
 Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/gcloud/reference/builds/submit) directly from the project directory
 ```bash

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -32,7 +32,7 @@ Install the dependencies in requirements.txt file
 
 ## Edit CloudBuild.yaml
 
-In the root directory, edit cloudbuid.yaml file `substitutions` variable values with the necessary credentials
+In the root directory, edit cloudbuid.yaml file `substitutions` variable values `CHANGEVALUE` with the necessary credentials
 
 ## Deploying the Application
 
@@ -42,7 +42,7 @@ Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/
 ```bash
 ~/DirectoryInsights$ gcloud builds submit
 ```
-_Note: `gcloud build submit` default config is "cloudbuild.yaml" which is why we do not need to specify `--config=config.yaml` tag_
+_Note: `gcloud builds submit` default config is "cloudbuild.yaml" which is why we do not need to specify `--config=config.yaml` tag_
 _Note: `.gcloudignore` file excludes unwanted files/folders from getting push in the deploy process_
 
 

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,11 +1,15 @@
 substitutions:
+  # Note: No quotations needed for the variable values, except for _SCHEDULE_CRON_TIME
+
   _JC_API_KEY: CHANGEVALUE # JC API key
   _JC_ORG_ID: CHANGEVALUE # JC ORG id
+  # JC Services: directory, radius, sso, systems, ldap, mdm
+  # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all
+  _JC_SERVICE: CHANGEVALUE
   _GCP_PROJECT_ID: CHANGEVALUE # GCP project Id
   _STORAGE_CLASS: CHANGEVALUE # Cloud Storage Class: standard, nearline, coldline, archive
   _BUCKET_NAME: CHANGEVALUE # Cloud Storage Bucket Name. Must be unique
   _FUNCTION_NAME: CHANGEVALUE # Cloud Functions Name
-  _JC_SERVICE: CHANGEVALUE # directory, radius, sso, systems, ldap, mdm
   _SCHEDULE_NAME: CHANGEVALUE # Cloud Scheduler Name
   _SCHEDULE_CRON_TIME: "CHANGEVALUE" # Check here: https://crontab.guru/
   _SERVICE_ACCOUNT_EMAIL: CHANGEVALUE # Service account with Cloud Functions Invoke permission
@@ -27,7 +31,7 @@ steps:
         printf "$_JC_API_KEY" | gcloud secrets create $_SECRET_JC_API_KEY_NAME --data-file=-
         printf "$_JC_ORG_ID" | gcloud secrets create $_SECRET_JC_ORG_ID_NAME --data-file=-
 
-  # Deploy the script to GCP
+  # Deploy the script to Google Cloud Functions as an HTTP trigger
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   args:
     - gcloud

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,15 +1,15 @@
 substitutions:
-  _JC_API_KEY: CHANGEVALUE
-  _JC_ORG_ID: CHANGEVALUE
+  _JC_API_KEY: CHANGEVALUE # JC API key
+  _JC_ORG_ID: CHANGEVALUE # JC ORG id
   _GCP_PROJECT_ID: CHANGEVALUE # GCP project Id
   _STORAGE_CLASS: CHANGEVALUE # Cloud Storage Class: standard, nearline, coldline, archive
   _BUCKET_NAME: CHANGEVALUE # Cloud Storage Bucket Name. Must be unique
   _FUNCTION_NAME: CHANGEVALUE # Cloud Functions Name
+  _JC_SERVICE: CHANGEVALUE # directory, radius, sso, systems, ldap, mdm
   _SCHEDULE_NAME: CHANGEVALUE # Cloud Scheduler Name
-  _SERVICE_ACCOUNT_EMAIL: CHANGEVALUE #Service account with Cloud Functions Invoke permission
-  _REGION_LOCATION: CHANGEVALUE #https://cloud.google.com/compute/docs/regions-zones
-  _FUNCTIONS_SERVICE: CHANGEVALUE #'directory', 'radius', 'sso', 'systems', 'ldap', 'mdm', 'all'
-  _SCHEDULE_CRON_TIME: "CHANGEVALUE" #https://crontab.guru/
+  _SCHEDULE_CRON_TIME: "CHANGEVALUE" # Check here: https://crontab.guru/
+  _SERVICE_ACCOUNT_EMAIL: CHANGEVALUE # Service account with Cloud Functions Invoke permission
+  _REGION_LOCATION: CHANGEVALUE # https://cloud.google.com/compute/docs/regions-zones
   _SECRET_JC_API_KEY_NAME: CHANGEVALUE # Secret Manager JCAPIKEY Name
   _SECRET_JC_ORG_ID_NAME: CHANGEVALUE # # Secret Manager JCORGID Name
 
@@ -40,7 +40,7 @@ steps:
     - --trigger-http
     - --runtime=python39
     - --set-secrets=jc_api_key=$_SECRET_JC_API_KEY_NAME:latest,jc_org_id=$_SECRET_JC_ORG_ID_NAME:latest
-    - --set-env-vars=^:^cron_schedule=$_SCHEDULE_CRON_TIME:service=$_FUNCTIONS_SERVICE:bucket_name=$_BUCKET_NAME
+    - --set-env-vars=^:^cron_schedule=$_SCHEDULE_CRON_TIME:service=$_JC_SERVICE:bucket_name=$_BUCKET_NAME
 
 # Schedule
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -40,7 +40,7 @@ steps:
     - --trigger-http
     - --runtime=python39
     - --set-secrets=jc_api_key=$_SECRET_JC_API_KEY_NAME:latest,jc_org_id=$_SECRET_JC_ORG_ID_NAME:latest
-    - --set-env-vars=cron_schedule=$_SCHEDULE_CRON_TIME,service=$_FUNCTIONS_SERVICE,bucket_name=$_BUCKET_NAME
+    - --set-env-vars=^:^cron_schedule=$_SCHEDULE_CRON_TIME:service=$_FUNCTIONS_SERVICE:bucket_name=$_BUCKET_NAME
 
 # Schedule
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -9,7 +9,7 @@ substitutions:
   _SERVICE_ACCOUNT_EMAIL: CHANGEVALUE #Service account with Cloud Functions Invoke permission
   _REGION_LOCATION: CHANGEVALUE #https://cloud.google.com/compute/docs/regions-zones
   _FUNCTIONS_SERVICE: CHANGEVALUE #'directory', 'radius', 'sso', 'systems', 'ldap', 'mdm', 'all'
-  _SCHEDULE_CRON_TIME: "<CHANGEVALUE>" #https://crontab.guru/
+  _SCHEDULE_CRON_TIME: "CHANGEVALUE" #https://crontab.guru/
   _SECRET_JC_API_KEY_NAME: CHANGEVALUE # Secret Manager JCAPIKEY Name
   _SECRET_JC_ORG_ID_NAME: CHANGEVALUE # # Secret Manager JCORGID Name
 

--- a/GCP/DirectoryInsights/deploy.yaml
+++ b/GCP/DirectoryInsights/deploy.yaml
@@ -1,0 +1,54 @@
+substitutions:
+  _JC_API_KEY: CHANGEVALUE
+  _JC_ORG_ID: CHANGEVALUE
+  _GCP_PROJECT_ID: CHANGEVALUE # GCP project Id
+  _STORAGE_CLASS: CHANGEVALUE # Cloud Storage Class: standard, nearline, coldline, archive
+  _BUCKET_NAME: CHANGEVALUE # Cloud Storage Bucket Name. Must be unique
+  _FUNCTION_NAME: CHANGEVALUE # Cloud Functions Name
+  _SCHEDULE_NAME: CHANGEVALUE # Cloud Scheduler Name
+  _SERVICE_ACCOUNT_EMAIL: CHANGEVALUE #Service account with Cloud Functions Invoke permission
+  _REGION_LOCATION: CHANGEVALUE #https://cloud.google.com/compute/docs/regions-zones
+  _FUNCTIONS_SERVICE: CHANGEVALUE #'directory', 'radius', 'sso', 'systems', 'ldap', 'mdm', 'all'
+  _SCHEDULE_CRON_TIME: "<CHANGEVALUE>" #https://crontab.guru/
+  _SECRET_JC_API_KEY_NAME: CHANGEVALUE # Secret Manager JCAPIKEY Name
+  _SECRET_JC_ORG_ID_NAME: CHANGEVALUE # # Secret Manager JCORGID Name
+
+steps:
+#  # Create a Storage bucket
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  args: ['gsutil', 'mb' , '-p', '$_GCP_PROJECT_ID', '-c','$_STORAGE_CLASS', '-l', '$_REGION_LOCATION', 'gs://$_BUCKET_NAME']
+
+  # Create secret keys for JCAPIKEY and JCORGID
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: bash
+  args:
+    - -c
+    - |
+        printf "$_JC_API_KEY" | gcloud secrets create $_SECRET_JC_API_KEY_NAME --data-file=-
+        printf "$_JC_ORG_ID" | gcloud secrets create $_SECRET_JC_ORG_ID_NAME --data-file=-
+
+  # Deploy the script to GCP
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  args:
+    - gcloud
+    - functions
+    - deploy
+    - $_FUNCTION_NAME
+    - --region=$_REGION_LOCATION
+    - --entry-point=run_di
+    - --source=.
+    - --trigger-http
+    - --runtime=python39
+    - --set-secrets=jc_api_key=$_SECRET_JC_API_KEY_NAME:latest,jc_org_id=$_SECRET_JC_ORG_ID_NAME:latest
+    - --set-env-vars=cron_schedule=$_SCHEDULE_CRON_TIME,service=$_FUNCTIONS_SERVICE,bucket_name=$_BUCKET_NAME
+
+# Schedule
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: bash
+  args:
+    - -c
+    - |
+      functionsURL=$(gcloud functions describe $_FUNCTION_NAME --region=$_REGION_LOCATION --flatten=httpsTrigger.url)
+      url=$(echo ${functionsURL} | grep -Eo 'https?://[^ ")]+')
+      echo "URL: $url"
+      gcloud scheduler jobs create http $_SCHEDULE_NAME --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$url" --http-method=GET --oidc-service-account-email="$_SERVICE_ACCOUNT_EMAIL"

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -9,9 +9,9 @@ from google.cloud import storage
 def jc_directory_insights():
     try:
         jc_api_key = os.environ['jc_api_key']
+        jc_org_id = os.environ['jc_org_id']
         cron_schedule = os.environ['cron_schedule']
         service =  os.environ['service']
-        jc_org_id = os.environ['jc_org_id']
         bucket_name = os.environ['bucket_name']
 
     except KeyError as e:
@@ -84,12 +84,12 @@ def jc_directory_insights():
         )
 
 # Http function for GC Functions
-def run_di(tester):
-    requests_args = tester.args
+def run_di(httpRequest):
+    requests_args = httpRequest.args
 
     if requests_args and "message" in requests_args:
         message = requests_args["message"]
     else:
         jc_directory_insights()
-        message = 'Created log'
+        message = 'DI successfully ran'
     return message

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -9,16 +9,17 @@ from google.cloud import storage
 def jc_directory_insights():
     try:
         jc_api_key = os.environ['jc_api_key']
-        cront_schedule = os.environ['cron_schedule']
-        service = os.environ['service']
+        cron_schedule = os.environ['cron_schedule']
+        service =  os.environ['service']
         jc_org_id = os.environ['jc_org_id']
         bucket_name = os.environ['bucket_name']
 
     except KeyError as e:
         raise Exception(e)
 
-    now = datetime.datetime.utcnow()
-    cron = croniter.croniter(cront_schedule, now)
+    date_now = datetime.datetime.utcnow()
+    now = date_now.replace(second=0, microsecond=0)
+    cron = croniter.croniter(cron_schedule, now)
     start_dt = cron.get_prev(datetime.datetime)
 
     start_date = start_dt.isoformat("T") + "Z"
@@ -83,8 +84,8 @@ def jc_directory_insights():
         )
 
 # Http function for GC Functions
-def run_di(requests):
-    requests_args = requests.args
+def run_di(tester):
+    requests_args = tester.args
 
     if requests_args and "message" in requests_args:
         message = requests_args["message"]

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -44,6 +44,7 @@ def jc_directory_insights():
         headers = {
             'x-api-key': jc_api_key,
             'content-type': "application/json",
+            'user-agent': 'JumpCloud_GCPServerless.DirectoryInsights/0.0.1'
         }
         if jc_org_id != '':
             headers['x-org-id'] = jc_org_id
@@ -64,13 +65,14 @@ def jc_directory_insights():
                 response.raise_for_status()
             except requests.exceptions.HTTPError as e:
                 raise Exception(e)
+
             response_body = json.loads(response.text)
             data = data + response_body
         final_data += data
+
     if len(final_data) == 0:
         return
     else:
-        print(final_data)
         outfile_name = "jc_directoryinsights_" + start_date + "_" + end_date + ".json"
         client = storage.Client()
         bucket = client.get_bucket(bucket_name)

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -1,0 +1,92 @@
+import croniter
+import datetime
+import json
+import os
+import requests
+from google.cloud import storage
+
+
+def jc_directory_insights():
+    try:
+        jc_api_key = os.environ['jc_api_key']
+        cront_schedule = os.environ['cron_schedule']
+        service = os.environ['service']
+        jc_org_id = os.environ['jc_org_id']
+        bucket_name = os.environ['bucket_name']
+
+    except KeyError as e:
+        raise Exception(e)
+
+    now = datetime.datetime.utcnow()
+    cron = croniter.croniter(cront_schedule, now)
+    start_dt = cron.get_prev(datetime.datetime)
+
+    start_date = start_dt.isoformat("T") + "Z"
+    end_date = now.isoformat("T") + "Z"
+
+    available_services = ['directory', 'radius', 'sso', 'systems', 'ldap', 'mdm', 'all']
+    service_list = ((service.replace(" ", "")).lower()).split(",")
+    for service in service_list:
+        if service not in available_services:
+            raise Exception(f"Unknown service: {service}")
+    if 'all' in service_list and len(service_list) > 1:
+        raise Exception(f"Error - Service List contains 'all' and additional services : {service_list}")
+    final_data = []
+
+    for service in service_list:
+        url = "https://api.jumpcloud.com/insights/directory/v1/events"
+        body = {
+            'service': [f"{service}"],
+            'start_time': start_date,
+            'end_time': end_date,
+            "limit": 10000
+        }
+        headers = {
+            'x-api-key': jc_api_key,
+            'content-type': "application/json",
+        }
+        if jc_org_id != '':
+            headers['x-org-id'] = jc_org_id
+        response = requests.post(url, json=body, headers=headers)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            raise Exception(e)
+
+        response_body = json.loads(response.text)
+        data = response_body
+
+        while response.headers["X-Result-Count"] >= response.headers["X-Limit"]:
+            body["search_after"] = json.loads(response.headers["X-Search_After"])
+            response = requests.post(url, json=body, headers=headers)
+            try:
+                response.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                raise Exception(e)
+            response_body = json.loads(response.text)
+            data = data + response_body
+        final_data += data
+    if len(final_data) == 0:
+        return
+    else:
+        print(final_data)
+        outfile_name = "jc_directoryinsights_" + start_date + "_" + end_date + ".json"
+        client = storage.Client()
+        bucket = client.get_bucket(bucket_name)
+        blob = bucket.blob(outfile_name)
+        blob.upload_from_string(
+            data=json.dumps(final_data),
+            content_type='application/json'
+        )
+
+# Http function for GC Functions
+def run_di(requests):
+    requests_args = requests.args
+
+    if requests_args and "message" in requests_args:
+        message = requests_args["message"]
+    else:
+        jc_directory_insights()
+        message = 'Created log'
+    return message

--- a/GCP/DirectoryInsights/requirements.txt
+++ b/GCP/DirectoryInsights/requirements.txt
@@ -1,8 +1,7 @@
 jcapiv1 @ git+https://github.com/TheJumpCloud/jcapi-python.git@35661f1e0380f58dc706a1f151d0db9118c2e8e9#subdirectory=jcapiv1
 jcapiv2 @ git+https://github.com/TheJumpCloud/jcapi-python.git@35661f1e0380f58dc706a1f151d0db9118c2e8e9#subdirectory=jcapiv2
-python-dateutil==2.8.2
-requests==2.27.1
-google-cloud-storage==2.2.1
-urllib3==1.26.9
-croniter==1.3.4
+python-dateutil~=2.8.2
+requests~=2.27.1
+google-cloud-storage~=2.2.1
+croniter~=1.3.4
 

--- a/GCP/DirectoryInsights/requirements.txt
+++ b/GCP/DirectoryInsights/requirements.txt
@@ -1,0 +1,8 @@
+jcapiv1 @ git+https://github.com/TheJumpCloud/jcapi-python.git@35661f1e0380f58dc706a1f151d0db9118c2e8e9#subdirectory=jcapiv1
+jcapiv2 @ git+https://github.com/TheJumpCloud/jcapi-python.git@35661f1e0380f58dc706a1f151d0db9118c2e8e9#subdirectory=jcapiv2
+python-dateutil==2.8.2
+requests==2.27.1
+google-cloud-storage==2.2.1
+urllib3==1.26.9
+croniter==1.3.4
+

--- a/GCP/DirectoryInsights/requirements.txt
+++ b/GCP/DirectoryInsights/requirements.txt
@@ -1,5 +1,3 @@
-jcapiv1 @ git+https://github.com/TheJumpCloud/jcapi-python.git@35661f1e0380f58dc706a1f151d0db9118c2e8e9#subdirectory=jcapiv1
-jcapiv2 @ git+https://github.com/TheJumpCloud/jcapi-python.git@35661f1e0380f58dc706a1f151d0db9118c2e8e9#subdirectory=jcapiv2
 python-dateutil~=2.8.2
 requests~=2.27.1
 google-cloud-storage~=2.2.1


### PR DESCRIPTION
## Issues
* [SA-2458](https://jumpcloud.atlassian.net/browse/SA-2458) - GCP parity for AWS DI App

## What does this solve?
Customers will now be able to use DI serverless app in GCP

## Is there anything particularly tricky?
No, just make sure you have Cloud Build Editor to deploy
## How should this be tested?
1. Save the to GCP/DirectoryInsights folder in your local machine
2. Edit cloudbuild.yaml `substitutions` variables with your credentials
3. Run the command `gcloud builds submit` with your terminal set to the DirectoryInsights folder
4. When Step 3 is finished, you have successfully deployed
6. Do some edits to your JC console to create some logs
7. Check Cloud Storage if the log has been stored after scheduled trigger ran
## Screenshots
Storage with JC_DI logs
![image](https://user-images.githubusercontent.com/97972790/161089163-d17d7b3c-abfb-4391-992b-575fe6323d7a.png)


