### PR TITLE
SA-3594-Dependency

### DIFF
--- a/GCP/DirectoryInsights/CHANGELOG.md
+++ b/GCP/DirectoryInsights/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [1.0.2] - 2023-09-25
+
+### Fixes
+- Updated Requests package version to 2.31.0 in the requirements file
 ## [1.0.1] - 2022-06-13
 
 ### Added

--- a/GCP/DirectoryInsights/requirements.txt
+++ b/GCP/DirectoryInsights/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil~=2.8.2
-requests~=2.27.1
+requests~=2.31.0
 google-cloud-storage~=2.2.1
 croniter~=1.3.4
 


### PR DESCRIPTION
## Issues
* [SA-3594](https://jumpcloud.atlassian.net/browse/sa-3594) - sa-3594-update-requests-dependency

## What does this solve?
Security update Requests version to 2.31.0 to address dependabot security warnings 
## Is there anything particularly tricky?
n/a
## How should this be tested?
Run GCP serverless app, make changes in your JC org (ie. system delete, user delete), validate that DI services changes are still getting stored in Cloud Storage



[SA-3594]: https://jumpcloud.atlassian.net/browse/SA-3594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ