### PR TITLE
API Key format change

### DIFF
--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -5,7 +5,7 @@ Parameters:
   JumpCloudApiKey:
     Type: String
     NoEcho: true
-    AllowedPattern: \b[a-z0-9]{40}\b
+    AllowedPattern: \b[a-zA-Z0-9_]{40}\b
   IncrementType:
     Type: String
     Default: day
@@ -43,7 +43,7 @@ Metadata:
     Name: JumpCloud-DirectoryInsights
     Description: This Serverless Application can be used to collect your JumpCloud Directory Insights data at a regular interval.
     Author: JumpCloud Solutions Architecture
-    SemanticVersion: 1.3.0
+    SemanticVersion: 1.3.1
     HomePageUrl: https://git.io/JJlrZ
     SourceCodeUrl: https://git.io/JJiMo
     LicenseUrl: LICENSE


### PR DESCRIPTION

## Issues
* N/A

## What does this solve?
The JumpCloud API Key has changed formats and now includes upper case, lower case, numerics and the underscore as valid characters.  Also increments the patch level to allow a new publish to the Serverless directory in AWS.

## Is there anything particularly tricky?
No, this is just a pattern match change to support the new API Key format

## How should this be tested?
A new API key should be accepted by the serverless template when deploying, instead of the old key format that is all lowercase letters and numbers.

## Screenshots
