### PR TITLE
CUT-4275-API-KEY-Pattern Change

### DIFF
--- a/AWS/DirectoryInsights/CHANGELOG.md
+++ b/AWS/DirectoryInsights/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [1.3.1] - 2024-09-12
+
+### Added
+
+- Added a change to allow for new API Key types
+
 ## [1.3.0] - 2023-12-13
 
 ### Added

--- a/AWS/DirectoryInsights/get-jcdirectoryinsights.py
+++ b/AWS/DirectoryInsights/get-jcdirectoryinsights.py
@@ -66,7 +66,7 @@ def jc_directoryinsights(event, context):
         headers = {
             'x-api-key': jcapikey,
             'content-type': "application/json",
-            'user-agent': "JumpCloud_AWSServerless.DirectoryInsights/1.3.0"
+            'user-agent': "JumpCloud_AWSServerless.DirectoryInsights/1.3.1"
         }
         if orgId != '':
             headers['x-org-id'] = orgId
@@ -89,7 +89,7 @@ def jc_directoryinsights(event, context):
                             },
                             {
                                 'Name': 'Version',
-                                'Value': '1.3.0'
+                                'Value': '1.3.1'
                             }
                         ],
                         'Unit': 'None',

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -5,7 +5,7 @@ Parameters:
   JumpCloudApiKey:
     Type: String
     NoEcho: true
-    AllowedPattern: \b[a-z0-9]{40}\b
+    AllowedPattern: \b[a-zA-Z0-9_]{40}\b
   IncrementType:
     Type: String
     Default: day
@@ -43,7 +43,7 @@ Metadata:
     Name: JumpCloud-DirectoryInsights
     Description: This Serverless Application can be used to collect your JumpCloud Directory Insights data at a regular interval.
     Author: JumpCloud Solutions Architecture
-    SemanticVersion: 1.3.0
+    SemanticVersion: 1.3.1
     HomePageUrl: https://git.io/JJlrZ
     SourceCodeUrl: https://git.io/JJiMo
     LicenseUrl: LICENSE

--- a/AWS/Users/serverless.yaml
+++ b/AWS/Users/serverless.yaml
@@ -5,7 +5,7 @@ Parameters:
   JumpCloudApiKey:
     Type: String
     NoEcho: true
-    AllowedPattern: \b[a-z0-9]{40}\b
+    AllowedPattern: \b[a-zA-Z0-9_]{40}\b
   IncrementType:
     Type: String
     Default: day


### PR DESCRIPTION
## Issues
* [CUT-4275](https://jumpcloud.atlassian.net/browse/CUT-4275) -  CUT-4275-API-KEY-Pattern Change

NOTE: Conitnuation of this [PR](https://github.com/TheJumpCloud/JumpCloud-Serverless/pull/22)
## What does this solve?
This change replaces API key regex pattern to account for the new JC API key types
## Is there anything particularly tricky?
n/a
## How should this be tested?
1. Deploy to AWS
2. Validate that the app is running properly
## Screenshots
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/cc62b1d9-c735-4ad5-9867-3035aa96e0da">
<img width="305" alt="image" src="https://github.com/user-attachments/assets/6c20c5f3-120e-41d6-ae36-50aa885e3ecb">


[CUT-4275]: https://jumpcloud.atlassian.net/browse/CUT-4275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ