### PR TITLE
Fix Serverless App Repo Installation Bug

### DIFF
--- a/AWS/DirectoryInsights/CHANGELOG.md
+++ b/AWS/DirectoryInsights/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## [1.3.2] - 2024-09-12
+
+### Added
+
+- Fixed application serverless repository installation not installing properly
+
 ## [1.3.1] - 2024-09-12
 
 ### Added
@@ -12,7 +19,6 @@
 - Added new services: password_manager, object_storage, software
 - Added parameter or option to format JSON to SingleLine or MultiLine
   
-# Changelog
 ## [1.2.1] - 2022-06-13
 
 ### Added

--- a/AWS/DirectoryInsights/get-jcdirectoryinsights.py
+++ b/AWS/DirectoryInsights/get-jcdirectoryinsights.py
@@ -66,7 +66,7 @@ def jc_directoryinsights(event, context):
         headers = {
             'x-api-key': jcapikey,
             'content-type': "application/json",
-            'user-agent': "JumpCloud_AWSServerless.DirectoryInsights/1.3.1"
+            'user-agent': "JumpCloud_AWSServerless.DirectoryInsights/1.3.2"
         }
         if orgId != '':
             headers['x-org-id'] = orgId
@@ -89,7 +89,7 @@ def jc_directoryinsights(event, context):
                             },
                             {
                                 'Name': 'Version',
-                                'Value': '1.3.1'
+                                'Value': '1.3.2'
                             }
                         ],
                         'Unit': 'None',

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -43,7 +43,7 @@ Metadata:
     Name: JumpCloud-DirectoryInsights
     Description: This Serverless Application can be used to collect your JumpCloud Directory Insights data at a regular interval.
     Author: JumpCloud Solutions Architecture
-    SemanticVersion: 1.3.1
+    SemanticVersion: 1.3.2
     HomePageUrl: https://git.io/JJlrZ
     SourceCodeUrl: https://git.io/JJiMo
     LicenseUrl: LICENSE


### PR DESCRIPTION
## Issues
* [CUT-4300](https://jumpcloud.atlassian.net/browse/CUT-4300) - CUT-4300-App-Repo-Installation-Bug

## What does this solve?
This solves the issue when installing the AWS DI app through AWS Serverless Application Repository not running properly due to incorrect packaged.yaml file uploaded. 

Note: AWS CLI installation works as expected.

## Is there anything particularly tricky?
n/a
## How should this be tested?
1. Create a packaged.yaml file
2. Upload to a test Serverless App Repo 
3. Validate that the test app is gathering data
