### PR TITLE
Update serverless.yaml

### DIFF
--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -5,7 +5,7 @@ Parameters:
   JumpCloudApiKey:
     Type: String
     NoEcho: true
-    AllowedPattern: \b[a-zA-Z0-9_]{40}\b
+    MinLength: 1
   IncrementType:
     Type: String
     Default: day


### PR DESCRIPTION
## Issues
* [CUT-4419](https://jumpcloud.atlassian.net/browse/CUT-4419) - CUT-4419-Remove-API-Key-Validation

## What does this solve?
Removes the regex and 40 char API key validation
## Is there anything particularly tricky?
n/a
## How should this be tested?
1. Deploy AWS serverless with an invalid API key that is not null (40+ characters is allowed) 
2. Application should be deployed


[CUT-4419]: https://jumpcloud.atlassian.net/browse/CUT-4419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ