### PR TITLE
Cut 5094 gcp 3.0

### DIFF
--- a/GCP/DirectoryInsights/.gcloudignore
+++ b/GCP/DirectoryInsights/.gcloudignore
@@ -1,3 +1,5 @@
-/venv
+.venv/
+env/
+venv/
 *.yaml
 *.png

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -20,11 +20,14 @@ _Note: This document assumes the use of Python 3.12 on GCP Cloud Functions_
 - [Create Directory to Store Directory Insights Files](#create-directory-to-store-directory-insights-files)
 - [Edit CloudBuild.yaml](#edit-cloudbuildyaml)
 - [Deploying the Application](#deploying-the-application)
+- [Manual Testing \& Historical Backfill](#manual-testing--historical-backfill)
+    - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console)
+    - [Option 2: Using the gcloud CLI](#option-2-using-the-gcloud-cli)
 - [Pipeline Architecture \& Error Handling (DLQ)](#pipeline-architecture--error-handling-dlq)
   - [Dead Letter Queue (DLQ)](#dead-letter-queue-dlq)
   - [Redriving Failed Messages](#redriving-failed-messages)
-    - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console)
-    - [Option 2: Using the gcloud CLI](#option-2-using-the-gcloud-cli)
+    - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console-1)
+    - [Option 2: Using the gcloud CLI](#option-2-using-the-gcloud-cli-1)
 - [Remove Cloud Build Roles](#remove-cloud-build-roles)
 
 # What This Application Builds
@@ -151,6 +154,50 @@ _Note: After a successful build, validate that each services are running properl
 ![alt text](image-3.png)
 
 Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/gcloud/reference/builds/submit) directly from the project directory
+
+
+# Manual Testing & Historical Backfill
+
+**⚠️ WARNING regarding Data Duplication:** Running a manual historical backfill for dates that have already been processed by the Cloud Scheduler (or running the same backfill multiple times) **will result in duplicate event records** in your Cloud Storage bucket. This application extracts raw data and does not inherently deduplicate existing storage files. If you need to backfill, ensure you are pulling a time window that hasn't been collected yet, or plan to deduplicate the data downstream (e.g., using `SELECT DISTINCT` queries in BigQuery).
+
+Instead of waiting for the Cloud Scheduler to fire, you can manually force the Orchestrator to perform a historical backfill (e.g., pulling the last 90 days of data). You can dynamically specify how many days back to look and which services to query using a simple JSON payload.
+
+### Option 1: Using the Google Cloud Console
+
+1.  Navigate to **Cloud Run** (or Cloud Functions) in the GCP Console.
+    
+2.  Click on your deployed Orchestrator function (e.g., `jc-di-orchestrator`).
+    
+3.  Click the **TESTING** tab near the top.
+    
+4.  In the **Triggering event** JSON box, paste the following payload:
+    
+    JSON
+    
+    ```
+    {
+      "event_days": 90,
+      "service": "all"
+    }
+    
+    ```
+    
+5.  Click **TEST THE FUNCTION**.
+    
+
+### Option 2: Using the gcloud CLI
+
+You can trigger the exact same payload directly from your terminal. The `gcloud` CLI automatically handles your authentication tokens:
+
+Bash
+
+```
+gcloud functions call jc-di-orchestrator --region=us-central1 --data='{"event_days": 90, "service": "all"}'
+
+```
+
+\_Note: You can change the `service` to specific endpoints like `"directory"` or `"systems"` for targeted testing._
+
 
 # Pipeline Architecture & Error Handling (DLQ)
 

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -21,8 +21,8 @@ _Note: This document assumes the use of Python 3.12 on GCP Cloud Functions_
 - [Edit CloudBuild.yaml](#edit-cloudbuildyaml)
 - [Deploying the Application](#deploying-the-application)
 - [Manual Testing \& Historical Backfill](#manual-testing--historical-backfill)
-    - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console)
-    - [Option 2: Using the gcloud CLI](#option-2-using-the-gcloud-cli)
+  - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console)
+  - [Option 2: Using the gcloud CLI](#option-2-using-the-gcloud-cli)
 - [Pipeline Architecture \& Error Handling (DLQ)](#pipeline-architecture--error-handling-dlq)
   - [Dead Letter Queue (DLQ)](#dead-letter-queue-dlq)
   - [Redriving Failed Messages](#redriving-failed-messages)
@@ -155,35 +155,43 @@ _Note: After a successful build, validate that each services are running properl
 
 Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/gcloud/reference/builds/submit) directly from the project directory
 
-
 # Manual Testing & Historical Backfill
 
 **⚠️ WARNING regarding Data Duplication:** Running a manual historical backfill for dates that have already been processed by the Cloud Scheduler (or running the same backfill multiple times) **will result in duplicate event records** in your Cloud Storage bucket. This application extracts raw data and does not inherently deduplicate existing storage files. If you need to backfill, ensure you are pulling a time window that hasn't been collected yet, or plan to deduplicate the data downstream (e.g., using `SELECT DISTINCT` queries in BigQuery).
 
-Instead of waiting for the Cloud Scheduler to fire, you can manually force the Orchestrator to perform a historical backfill (e.g., pulling the last 90 days of data). You can dynamically specify how many days back to look and which services to query using a simple JSON payload.
+Instead of waiting for the Cloud Scheduler to fire, you can manually invoke the Orchestrator with an explicit **UTC** time window using **`start_time`** and **`end_time`**. You can use **ISO-8601** timestamps, or **dynamic** values that are resolved when the function runs:
+
+- **`"now"`** — current instant (UTC).
+- **`"now-30"`** or **`"now-30d"`** — 30 **days** before `now` (omit the suffix to mean days).
+- **`"now-24h"`**, **`"now-90m"`**, **`"now-3600s"`** — hours, minutes, or seconds before `now`.
+
+Example: last 30 days through the current moment:
+
+```json
+{ "start_time": "now-30", "end_time": "now" }
+```
+
+Optionally set **`service`** to override the function’s default. Omit **`start_time`** and **`end_time`** entirely to use the normal cron window for that run.
 
 ### Option 1: Using the Google Cloud Console
 
 1.  Navigate to **Cloud Run** (or Cloud Functions) in the GCP Console.
-    
 2.  Click on your deployed Orchestrator function (e.g., `jc-di-orchestrator`).
-    
 3.  Click the **TESTING** tab near the top.
-    
 4.  In the **Triggering event** JSON box, paste the following payload:
-    
+
     JSON
-    
+
     ```
     {
-      "event_days": 90,
+      "start_time": "2026-03-01T00:00:00Z",
+      "end_time": "2026-03-31T23:59:59Z",
       "service": "all"
     }
-    
+
     ```
-    
+
 5.  Click **TEST THE FUNCTION**.
-    
 
 ### Option 2: Using the gcloud CLI
 
@@ -192,12 +200,11 @@ You can trigger the exact same payload directly from your terminal. The `gcloud`
 Bash
 
 ```
-gcloud functions call jc-di-orchestrator --region=us-central1 --data='{"event_days": 90, "service": "all"}'
+gcloud functions call jc-di-orchestrator --region=us-central1 --data='{"start_time":"2026-03-01T00:00:00Z","end_time":"2026-03-31T23:59:59Z","service":"all"}'
 
 ```
 
-\_Note: You can change the `service` to specific endpoints like `"directory"` or `"systems"` for targeted testing._
-
+\_Note: You can change the `service` to specific endpoints like `"directory"` or `"systems"` for targeted testing.\_
 
 # Pipeline Architecture & Error Handling (DLQ)
 

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -1,4 +1,5 @@
 # Gather JumpCloud Directory Insights Data with GCP Services
+
 _This document will walk a JumpCloud Administrator through deploying this Serverless Application to GCP._
 
 _Note: This document assumes the use of Python 3.12 on GCP Cloud Functions_
@@ -36,55 +37,44 @@ The `gcloud builds submit` command orchestrates the creation of the following in
 
 ### 1. Cloud Functions (3 Total)
 
--   **Orchestrator Function:** An HTTP-triggered function that acts as the "brain." It calculates the time window (e.g., the last 5 minutes) and determines how many parallel jobs are needed based on the event count in JumpCloud.
-    
--   **Worker Function:** A background function triggered by Pub/Sub. It performs the heavy lifting: querying the JumpCloud API, paginating through results, sanitizing data for BigQuery compatibility, and uploading compressed GZIP files to Storage.
-    
--   **Redrive Function:** An administrative HTTP function used to move failed messages from the Dead Letter Queue back into the main processing pipeline. Whenever a job fails 5 times, it sits in the DLQ; this function "redrives" those jobs so they can be processed by the Worker again once the issue (like an API outage) is resolved.
-    
+- **Orchestrator Function:** An HTTP-triggered function that acts as the "brain." It calculates the time window (e.g., the last 5 minutes) and determines how many parallel jobs are needed based on the event count in JumpCloud.
+- **Worker Function:** A background function triggered by Pub/Sub. It performs the heavy lifting: querying the JumpCloud API, paginating through results, sanitizing data for BigQuery compatibility, and uploading compressed GZIP files to Storage.
+- **Redrive Function:** An administrative HTTP function used to move failed messages from the Dead Letter Queue back into the main processing pipeline. Whenever a job fails 5 times, it sits in the DLQ; this function "redrives" those jobs so they can be processed by the Worker again once the issue (like an API outage) is resolved.
 
 ### 2. Pub/Sub Messaging Layer
 
--   **Main Topic (`jc-di-jobs`):** The communication channel where the Orchestrator posts job instructions for the Workers to pick up.
-    
--   **Dead Letter Topic (`jc-di-jobs-dlq`):** A safety net topic where jobs are sent if they fail to process after 5 consecutive attempts.
-    
--   **Pull Subscription:** A dedicated subscription on the DLQ topic that holds failed messages until they are redriven or expire.
--   **ReDrive Function:** A dedicated subscription on the DLQ topic that holds failed messages until they are redriven or expire.
-    
+- **Main Topic (`jc-di-jobs`):** The communication channel where the Orchestrator posts job instructions for the Workers to pick up.
+- **Dead Letter Topic (`jc-di-jobs-dlq`):** A safety net topic where jobs are sent if they fail to process after 5 consecutive attempts.
+- **Pull Subscription:** A dedicated subscription on the DLQ topic that holds failed messages until they are redriven or expire.
+- **ReDrive Function:** A dedicated subscription on the DLQ topic that holds failed messages until they are redriven or expire.
 
 ### 3. Cloud Storage
 
--   **Data Bucket:** A permanent storage location for your Directory Insights logs. Files are stored as compressed GZIP files, supporting **MultiLine**, **SingleLine**, or **NDJson** formats.
-    
+- **Data Bucket:** A permanent storage location for your Directory Insights logs. Files are stored as compressed GZIP files, supporting **MultiLine**, **SingleLine**, or **NDJson** formats.
 
 ### 4. Cloud Scheduler
 
--   **Cron Job:** A managed scheduler that pings the Orchestrator at your defined interval (e.g., every 5 minutes) to ensure continuous data collection.
-    
+- **Cron Job:** A managed scheduler that pings the Orchestrator at your defined interval (e.g., every 5 minutes) to ensure continuous data collection.
 
 ### 5. Secret Manager
 
--   **API Credentials:** Secure storage for your `JumpCloud API Key` and `Organization ID`, ensuring no sensitive credentials are hardcoded in the functions or environment variables.
-    
+- **API Credentials:** Secure storage for your `JumpCloud API Key` and `Organization ID`, ensuring no sensitive credentials are hardcoded in the functions or environment variables.
 
 ## Key Features
 
--   **Auto-Scaling:** If JumpCloud has 100,000 events in a 5-minute window, the Orchestrator will automatically split that into multiple Pub/Sub messages, allowing multiple Worker instances to process the data simultaneously.
-    
--   **BigQuery Ready:** When using the `NDJson` format, the application automatically sanitizes JSON keys (replacing spaces/hyphens with underscores) to ensure the files can be ingested into BigQuery without schema errors.
-    
--   **Manual Recovery:** The "Force Run" logic allows you to trigger a large historical backfill (up to 90 days) simply by clicking "Force Run" in the Cloud Scheduler console.
+- **Auto-Scaling:** If JumpCloud has 100,000 events in a 5-minute window, the Orchestrator will automatically split that into multiple Pub/Sub messages, allowing multiple Worker instances to process the data simultaneously.
+- **BigQuery Ready:** When using the `NDJson` format, the application automatically sanitizes JSON keys (replacing spaces/hyphens with underscores) to ensure the files can be ingested into BigQuery without schema errors.
+- **Manual Recovery:** The "Force Run" logic allows you to trigger a large historical backfill (up to 90 days) simply by clicking "Force Run" in the Cloud Scheduler console.
 
 # Pre-requisites
 
 - [Your JumpCloud API key](https://docs.jumpcloud.com/2.0/authentication-and-authorization/authentication-and-authorization-overview)
 - Google Cloud Admin/Owner account with these roles:
-  - ```roles/serviceusage.serviceUsageAdmin```
-  - ```roles/cloudbuild.builds.editor```
-  - ```roles/resourcemanager.projects.setIamPolicy```
+  - `roles/serviceusage.serviceUsageAdmin`
+  - `roles/cloudbuild.builds.editor`
+  - `roles/resourcemanager.projects.setIamPolicy`
 - [GCLOUD CLI installed](https://cloud.google.com/sdk/docs/install)
-  - After installing the CLI, run ```gcloud auth login``` and login with your Admin/Owner account
+  - After installing the CLI, run `gcloud auth login` and login with your Admin/Owner account
 - On your CLI, run these commands to enable the [services](https://cloud.google.com/apis?hl=en) needed to build the app:
 
 ```bash
@@ -98,14 +88,16 @@ gcloud services enable pubsub.googleapis.com
 ```
 
 - Your GCP Project ID and Number. You can automatically fetch and set these as variables in your CLI so you won't need to manually insert them in the commands below. Run this block in your terminal:
+
 ```bash
 PROJECTID=$(gcloud config get-value project)
 PROJECTNUM=$(gcloud projects describe $PROJECTID --format="value(projectNumber)")
 echo "Project ID set to: $PROJECTID"
 echo "Project Number set to: $PROJECTNUM"
 ```
-- You must assign the Cloud Build Service account ```ProjectNumber@cloudbuild.gserviceaccount.com``` [roles](https://console.cloud.google.com/cloud-build/settings/). This account serves as an identity with specific roles to build the necessary services. [Cloud Build Service Account](https://cloud.google.com/build/docs/cloud-build-service-account)
-  
+
+- You must assign the Cloud Build Service account `ProjectNumber@cloudbuild.gserviceaccount.com` [roles](https://console.cloud.google.com/cloud-build/settings/). This account serves as an identity with specific roles to build the necessary services. [Cloud Build Service Account](https://cloud.google.com/build/docs/cloud-build-service-account)
+
 ```bash
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/iam.serviceAccountUser
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/secretmanager.admin
@@ -120,15 +112,13 @@ gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJE
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/resourcemanager.projectIamAdmin
 ```
 
-
 - You must assign roles to the compute developer service account to access the secrets manager
 
 ```bash
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role roles/secretmanager.secretAccessor
 ```
 
-
-- You must also assign roles to the App Engine service account ```*@appspot.gserviceaccount.com```. This account serves as identity when accessing Cloud Storage and Secret Manager. [Function Identity](https://cloud.google.com/functions/docs/securing/function-identity#:~:text=Every%20function%20is%20associated%20with,as%20its%20runtime%20service%20account.)
+- You must also assign roles to the App Engine service account `*@appspot.gserviceaccount.com`. This account serves as identity when accessing Cloud Storage and Secret Manager. [Function Identity](https://cloud.google.com/functions/docs/securing/function-identity#:~:text=Every%20function%20is%20associated%20with,as%20its%20runtime%20service%20account.)
 
 ```bash
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTID@appspot.gserviceaccount.com --role roles/secretmanager.secretAccessor
@@ -136,7 +126,7 @@ gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJE
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTID@appspot.gserviceaccount.com --role roles/run.admin
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTID@appspot.gserviceaccount.com --role roles/cloudfunctions.admin
 ```
-  
+
 # Create Directory to Store Directory Insights Files
 
 Create a directory to store your Serverless Application and any dependencies required. In the root of that directory add [Directory Insights Files](https://github.com/TheJumpCloud/JumpCloud-Serverless/blob/master/GCP/DirectoryInsights/).
@@ -155,25 +145,27 @@ Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/
 
 _Note: `gcloud builds submit` default config is "cloudbuild.yaml" which is why we do not need to specify `--config=config.yaml` tag_
 _Note: `.gcloudignore` file excludes unwanted files/folders from getting push in the deploy process_
-_Note: After a succesfull build, validate that each services are running properly. You can do this by doing a FORCE RUN on the schedule we created, this will trigger the function to run the DI app script and saved the log files to Cloud Scheduler:_
+_Note: After a successful build, validate that each services are running properly. You can do this by doing a FORCE RUN on the schedule we created, this will trigger the function to run the DI app script and saved the log files to Cloud Scheduler:_
 ![alt text](image-1.png)
 ![alt text](image.png)
 ![alt text](image-3.png)
-
 
 Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/gcloud/reference/builds/submit) directly from the project directory
 
 # Pipeline Architecture & Error Handling (DLQ)
 
 ## Dead Letter Queue (DLQ)
+
 If the JumpCloud API is temporarily down, times out, or a job fails for any reason, the Worker will automatically retry the job up to 5 times using exponential backoff. If it fails on the 5th attempt, the data is not lost. Instead, the job payload is safely moved to a Dead Letter Queue (DLQ) topic (jc-di-jobs-dlq).
 
 ## Redriving Failed Messages
+
 Once you have resolved the underlying issue (e.g., an API outage is over), you can easily push the failed messages from the DLQ back into the main pipeline to be processed again. This is called a "Redrive".
 
 The deployment automatically creates a Redrive Cloud Function for you. You can trigger it in two ways:
 
 ### Option 1: Using the Google Cloud Console
+
 1. Navigate to Cloud Run (or Cloud Functions) in the GCP Console.
 
 2. Click on your deployed redrive service (e.g., jc-di-redrive).
@@ -185,16 +177,18 @@ The deployment automatically creates a Redrive Cloud Function for you. You can t
 The output will tell you exactly how many messages were successfully moved back to the main queue.
 
 ### Option 2: Using the gcloud CLI
+
 Run the following command in your terminal:
 
 ```bash
 gcloud functions call jc-di-redrive --region=us-central1
 ```
-_Note: Replace jc-di-redrive and us-central1 in the command above if you modified your cloudbuild.yaml substitutions.
+
+\_Note: Replace jc-di-redrive and us-central1 in the command above if you modified your cloudbuild.yaml substitutions.
 
 # Remove Cloud Build Roles
 
-_Note: After a successful build, it is good practice to cleanup the roles we provided to the Cloud Build service account as it is not needed to be used anymore. On your CLI, run the commands below:
+\_Note: After a successful build, it is good practice to cleanup the roles we provided to the Cloud Build service account as it is not needed to be used anymore. On your CLI, run the commands below:
 
 ```bash
 #Cloud Functions Developer

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -1,19 +1,82 @@
 # Gather JumpCloud Directory Insights Data with GCP Services
 _This document will walk a JumpCloud Administrator through deploying this Serverless Application to GCP._
 
-_Note: This document assumes the use of Python 3.9 on GCP Cloud Functions_
+_Note: This document assumes the use of Python 3.12 on GCP Cloud Functions_
 
-## Table of Contents
+# Table of Contents
 
 - [Gather JumpCloud Directory Insights Data with GCP Services](#gather-jumpcloud-directory-insights-data-with-gcp-services)
-  - [Table of Contents](#table-of-contents)
-  - [Pre-requisites](#pre-requisites)
-  - [Create Directory to Store Directory Insights Files](#create-directory-to-store-directory-insights-files)
-  - [Edit CloudBuild.yaml](#edit-cloudbuildyaml)
-  - [Deploying the Application](#deploying-the-application)
-  - [Remove Cloud Build Roles](#remove-cloud-build-roles)
+- [Table of Contents](#table-of-contents)
+- [What This Application Builds](#what-this-application-builds)
+  - [Deployed Components](#deployed-components)
+    - [1. Cloud Functions (3 Total)](#1-cloud-functions-3-total)
+    - [2. Pub/Sub Messaging Layer](#2-pubsub-messaging-layer)
+    - [3. Cloud Storage](#3-cloud-storage)
+    - [4. Cloud Scheduler](#4-cloud-scheduler)
+    - [5. Secret Manager](#5-secret-manager)
+  - [Key Features](#key-features)
+- [Pre-requisites](#pre-requisites)
+- [Create Directory to Store Directory Insights Files](#create-directory-to-store-directory-insights-files)
+- [Edit CloudBuild.yaml](#edit-cloudbuildyaml)
+- [Deploying the Application](#deploying-the-application)
+- [Pipeline Architecture \& Error Handling (DLQ)](#pipeline-architecture--error-handling-dlq)
+  - [Dead Letter Queue (DLQ)](#dead-letter-queue-dlq)
+  - [Redriving Failed Messages](#redriving-failed-messages)
+    - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console)
+    - [Option 2: Using the gcloud CLI](#option-2-using-the-gcloud-cli)
+- [Remove Cloud Build Roles](#remove-cloud-build-roles)
 
-## Pre-requisites
+# What This Application Builds
+
+This serverless application automates the extraction of **JumpCloud Directory Insights** data and stores it in **Google Cloud Storage**. By utilizing an event-driven "Orchestrator-Worker" pattern, it efficiently handles large volumes of event logs without hitting Cloud Function execution limits.
+
+## Deployed Components
+
+The `gcloud builds submit` command orchestrates the creation of the following infrastructure:
+
+### 1. Cloud Functions (3 Total)
+
+-   **Orchestrator Function:** An HTTP-triggered function that acts as the "brain." It calculates the time window (e.g., the last 5 minutes) and determines how many parallel jobs are needed based on the event count in JumpCloud.
+    
+-   **Worker Function:** A background function triggered by Pub/Sub. It performs the heavy lifting: querying the JumpCloud API, paginating through results, sanitizing data for BigQuery compatibility, and uploading compressed GZIP files to Storage.
+    
+-   **Redrive Function:** An administrative HTTP function used to move failed messages from the Dead Letter Queue back into the main processing pipeline. Whenever a job fails 5 times, it sits in the DLQ; this function "redrives" those jobs so they can be processed by the Worker again once the issue (like an API outage) is resolved.
+    
+
+### 2. Pub/Sub Messaging Layer
+
+-   **Main Topic (`jc-di-jobs`):** The communication channel where the Orchestrator posts job instructions for the Workers to pick up.
+    
+-   **Dead Letter Topic (`jc-di-jobs-dlq`):** A safety net topic where jobs are sent if they fail to process after 5 consecutive attempts.
+    
+-   **Pull Subscription:** A dedicated subscription on the DLQ topic that holds failed messages until they are redriven or expire.
+-   **ReDrive Function:** A dedicated subscription on the DLQ topic that holds failed messages until they are redriven or expire.
+    
+
+### 3. Cloud Storage
+
+-   **Data Bucket:** A permanent storage location for your Directory Insights logs. Files are stored as compressed GZIP files, supporting **MultiLine**, **SingleLine**, or **NDJson** formats.
+    
+
+### 4. Cloud Scheduler
+
+-   **Cron Job:** A managed scheduler that pings the Orchestrator at your defined interval (e.g., every 5 minutes) to ensure continuous data collection.
+    
+
+### 5. Secret Manager
+
+-   **API Credentials:** Secure storage for your `JumpCloud API Key` and `Organization ID`, ensuring no sensitive credentials are hardcoded in the functions or environment variables.
+    
+
+## Key Features
+
+-   **Auto-Scaling:** If JumpCloud has 100,000 events in a 5-minute window, the Orchestrator will automatically split that into multiple Pub/Sub messages, allowing multiple Worker instances to process the data simultaneously.
+    
+-   **BigQuery Ready:** When using the `NDJson` format, the application automatically sanitizes JSON keys (replacing spaces/hyphens with underscores) to ensure the files can be ingested into BigQuery without schema errors.
+    
+-   **Manual Recovery:** The "Force Run" logic allows you to trigger a large historical backfill (up to 90 days) simply by clicking "Force Run" in the Cloud Scheduler console.
+
+# Pre-requisites
 
 - [Your JumpCloud API key](https://docs.jumpcloud.com/2.0/authentication-and-authorization/authentication-and-authorization-overview)
 - Google Cloud Admin/Owner account with these roles:
@@ -31,24 +94,30 @@ gcloud services enable cloudscheduler.googleapis.com
 gcloud services enable storage-component.googleapis.com
 gcloud services enable secretmanager.googleapis.com
 gcloud services enable cloudresourcemanager.googleapis.com
+gcloud services enable pubsub.googleapis.com
 ```
 
-- Your GCP Project ID and Number, on your CLI you can run ```gcloud projects list``` to get your project's name and ID
-  - On your CLI create a variable for Project ID and Number so that you won't need to insert these variables on the commands below:
-    - ```PROJECTID=INSERTYOURGCPID```
-    - ```PROJECTNUM=INSERTYOURGCPNUM```
+- Your GCP Project ID and Number. You can automatically fetch and set these as variables in your CLI so you won't need to manually insert them in the commands below. Run this block in your terminal:
+```bash
+PROJECTID=$(gcloud config get-value project)
+PROJECTNUM=$(gcloud projects describe $PROJECTID --format="value(projectNumber)")
+echo "Project ID set to: $PROJECTID"
+echo "Project Number set to: $PROJECTNUM"
+```
 - You must assign the Cloud Build Service account ```ProjectNumber@cloudbuild.gserviceaccount.com``` [roles](https://console.cloud.google.com/cloud-build/settings/). This account serves as an identity with specific roles to build the necessary services. [Cloud Build Service Account](https://cloud.google.com/build/docs/cloud-build-service-account)
   
 ```bash
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/iam.serviceAccountUser
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role roles/secretmanager.admin
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role roles/storage.admin
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role roles/run.admin
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role roles/cloudbuild.builds.builder
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role roles/cloudscheduler.admin
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role roles/secretmanager.secretAccessor
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role roles/cloudfunctions.invoker
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role roles/cloudfunctions.developer
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/secretmanager.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/storage.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/run.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/cloudbuild.builds.builder
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/cloudscheduler.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/secretmanager.secretAccessor
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/cloudfunctions.invoker
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/cloudfunctions.developer
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/pubsub.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/resourcemanager.projectIamAdmin
 ```
 
 
@@ -68,15 +137,15 @@ gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJE
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTID@appspot.gserviceaccount.com --role roles/cloudfunctions.admin
 ```
   
-## Create Directory to Store Directory Insights Files
+# Create Directory to Store Directory Insights Files
 
 Create a directory to store your Serverless Application and any dependencies required. In the root of that directory add [Directory Insights Files](https://github.com/TheJumpCloud/JumpCloud-Serverless/blob/master/GCP/DirectoryInsights/).
 
-## Edit CloudBuild.yaml
+# Edit CloudBuild.yaml
 
 In the root directory, edit cloudbuid.yaml file `substitutions` variable values `CHANGEVALUE` with the necessary credentials
 
-## Deploying the Application
+# Deploying the Application
 
 Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/gcloud/reference/builds/submit) directly from the project directory
 
@@ -94,7 +163,36 @@ _Note: After a succesfull build, validate that each services are running properl
 
 Using the GCLOUD CLI, you can [Cloud Build Deploy](https://cloud.google.com/sdk/gcloud/reference/builds/submit) directly from the project directory
 
-## Remove Cloud Build Roles
+# Pipeline Architecture & Error Handling (DLQ)
+
+## Dead Letter Queue (DLQ)
+If the JumpCloud API is temporarily down, times out, or a job fails for any reason, the Worker will automatically retry the job up to 5 times using exponential backoff. If it fails on the 5th attempt, the data is not lost. Instead, the job payload is safely moved to a Dead Letter Queue (DLQ) topic (jc-di-jobs-dlq).
+
+## Redriving Failed Messages
+Once you have resolved the underlying issue (e.g., an API outage is over), you can easily push the failed messages from the DLQ back into the main pipeline to be processed again. This is called a "Redrive".
+
+The deployment automatically creates a Redrive Cloud Function for you. You can trigger it in two ways:
+
+### Option 1: Using the Google Cloud Console
+1. Navigate to Cloud Run (or Cloud Functions) in the GCP Console.
+
+2. Click on your deployed redrive service (e.g., jc-di-redrive).
+
+3. Click the TESTING tab near the top.
+
+4. Click the TEST THE FUNCTION button.
+
+The output will tell you exactly how many messages were successfully moved back to the main queue.
+
+### Option 2: Using the gcloud CLI
+Run the following command in your terminal:
+
+```bash
+gcloud functions call jc-di-redrive --region=us-central1
+```
+_Note: Replace jc-di-redrive and us-central1 in the command above if you modified your cloudbuild.yaml substitutions.
+
+# Remove Cloud Build Roles
 
 _Note: After a successful build, it is good practice to cleanup the roles we provided to the Cloud Build service account as it is not needed to be used anymore. On your CLI, run the commands below:
 

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -8,11 +8,10 @@ substitutions:
   _SCHEDULE_CRON_TIME: "CHANGEVALUE" # Ref: https://crontab.guru/
   _GCP_PROJECT_ID_NAME: "CHANGEVALUE"
   _JSON_FORMAT: "CHANGEVALUE" # MutiLine, SingleLine, NDJson
-  _STORAGE_CLASS: "CHANGEVALUE" # Cloud Storage Class: standard, nearline, coldline, archive
+  _STORAGE_CLASS: "CHANGEVALUE" # Cloud Storage Class: standard, nearline, coldline, archive https://docs.cloud.google.com/storage/docs/storage-classes
   _REGION_LOCATION: "CHANGEVALUE" # https://cloud.google.com/compute/docs/regions-zones
-  _FORCE_RUN_DAYS: "30" # Change this when doing a force run test using the scheduler
   _MAX_EVENTS_PER_WORKER: "25000"
-  _WORKER_MEMORY: "512MB"
+  _WORKER_MEMORY: "512MB" # https://docs.cloud.google.com/run/docs/configuring/services/memory-limits
 
 steps:
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
@@ -64,7 +63,7 @@ steps:
       - --region=$_REGION_LOCATION
       - --source=.
       - --runtime=python312
-      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,force_run_days=$_FORCE_RUN_DAYS,max_events_per_worker=$_MAX_EVENTS_PER_WORKER
+      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,max_events_per_worker=$_MAX_EVENTS_PER_WORKER
       - --entry-point=jc_orchestrator
       - --trigger-http
       - --no-allow-unauthenticated

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,28 +1,21 @@
 substitutions:
   _JC_API_KEY: "CHANGEVALUE"
   _JC_ORG_ID: "CHANGEVALUE"
-  _JC_SERVICE: "CHANGEVALUE"   # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services: 
+  _JC_SERVICE: "CHANGEVALUE" # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services:
   ### all, access_management, alerts, asset_management, directory, ldap, mdm, notifications, object_storage, password_manager, radius, reports, saas_app_management, software, sso, systems, workflows. ###
-  _SCHEDULE_CRON_TIME: "CHANGEVALUE"  # Ref: https://crontab.guru/
-  _GCP_PROJECT_ID_NAME: "CHANGEVALUE" 
-  _BUCKET_NAME: "CHANGEVALUE"
-  _JSON_FORMAT: "MultiLine"   # MutiLine, SingleLine, NDJson
-  _STORAGE_CLASS: "standard" 
-  _ORCHESTRATOR_FUNCTION_NAME: "jc-di-orchestrator" 
-  _WORKER_FUNCTION_NAME: "jc-di-worker"
-  _REDRIVE_FUNCTION_NAME: "jc-di-redrive" 
-  _PUBSUB_TOPIC: "jc-di-jobs"
-  _PUBSUB_DLQ_TOPIC: "jc-di-jobs-dlq" 
-  _SCHEDULE_NAME: "jc-di-schedule" 
-  _REGION_LOCATION: "us-central1" 
-  _SECRET_JC_API_KEY_NAME: "jc-api-key" 
-  _SECRET_JC_ORG_ID_NAME: "jc-org-id"
+  # Prefix for GCS bucket, secrets, functions, Pub/Sub, and scheduler.
+  _RESOURCE_PREFIX: "jc-di"
+  _SCHEDULE_CRON_TIME: "CHANGEVALUE" # Ref: https://crontab.guru/
+  _GCP_PROJECT_ID_NAME: "CHANGEVALUE"
+  _JSON_FORMAT: "MultiLine" # MutiLine, SingleLine, NDJson
+  _STORAGE_CLASS: "standard"
+  _REGION_LOCATION: "us-central1"
   _FORCE_RUN_DAYS: "30" # Change this when doing a force run test using the scheduler
   _MAX_EVENTS_PER_WORKER: "25000"
   _WORKER_MEMORY: "512MB"
 
 steps:
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: bash
     args:
       - -c
@@ -31,80 +24,80 @@ steps:
           exit 1
         fi
 
-# Storage bucket creation
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  # Storage bucket creation
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: bash
     args:
       - -c
       - |
-        gsutil ls -p $_GCP_PROJECT_ID_NAME gs://$_BUCKET_NAME >/dev/null 2>&1 || \
-        gsutil mb -p $_GCP_PROJECT_ID_NAME -c $_STORAGE_CLASS -l $_REGION_LOCATION gs://$_BUCKET_NAME
+        gsutil ls -p $_GCP_PROJECT_ID_NAME gs://${_RESOURCE_PREFIX}-di-bucket >/dev/null 2>&1 || \
+        gsutil mb -p $_GCP_PROJECT_ID_NAME -c $_STORAGE_CLASS -l $_REGION_LOCATION gs://${_RESOURCE_PREFIX}-di-bucket
 
   # Create Secrets
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: bash
     args:
       - -c
       - |
-        echo -n "$_JC_API_KEY" | gcloud secrets create $_SECRET_JC_API_KEY_NAME --data-file=- || true
-        echo -n "$_JC_ORG_ID" | gcloud secrets create $_SECRET_JC_ORG_ID_NAME --data-file=- || true
+        echo -n "$_JC_API_KEY" | gcloud secrets create ${_RESOURCE_PREFIX}-api-key --data-file=- || true
+        echo -n "$_JC_ORG_ID" | gcloud secrets create ${_RESOURCE_PREFIX}-org-id --data-file=- || true
 
   # Create Pub/Sub Topics (Main queue and DLQ)
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: bash
     args:
       - -c
       - |
         # Create Main Topic
-        gcloud pubsub topics describe $_PUBSUB_TOPIC || gcloud pubsub topics create $_PUBSUB_TOPIC
-        
+        gcloud pubsub topics describe ${_RESOURCE_PREFIX}-jobs || gcloud pubsub topics create ${_RESOURCE_PREFIX}-jobs
+
         # Create Dead Letter Topic
-        gcloud pubsub topics describe $_PUBSUB_DLQ_TOPIC || gcloud pubsub topics create $_PUBSUB_DLQ_TOPIC
+        gcloud pubsub topics describe ${_RESOURCE_PREFIX}-jobs-dlq || gcloud pubsub topics create ${_RESOURCE_PREFIX}-jobs-dlq
 
   # Deploy the Orchestrator Cloud Function (HTTP Triggered)
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     args:
-    - gcloud
-    - functions
-    - deploy
-    - $_ORCHESTRATOR_FUNCTION_NAME
-    - --region=$_REGION_LOCATION
-    - --source=.
-    - --runtime=python312
-    - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=$_SECRET_JC_API_KEY_NAME,jc_org_id=$_SECRET_JC_ORG_ID_NAME,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=$_PUBSUB_TOPIC,force_run_days=$_FORCE_RUN_DAYS,max_events_per_worker=$_MAX_EVENTS_PER_WORKER
-    - --entry-point=jc_orchestrator
-    - --trigger-http
-    - --no-allow-unauthenticated
-    - --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
+      - gcloud
+      - functions
+      - deploy
+      - ${_RESOURCE_PREFIX}-orchestrator
+      - --region=$_REGION_LOCATION
+      - --source=.
+      - --runtime=python312
+      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,force_run_days=$_FORCE_RUN_DAYS,max_events_per_worker=$_MAX_EVENTS_PER_WORKER
+      - --entry-point=jc_orchestrator
+      - --trigger-http
+      - --no-allow-unauthenticated
+      - --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
 
   # Deploy the Worker Cloud Function & Configure DLQ
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: bash
     args:
       - -c
       - |
         # 1. Deploy the function
-        gcloud functions deploy $_WORKER_FUNCTION_NAME \
+        gcloud functions deploy ${_RESOURCE_PREFIX}-worker \
           --region=$_REGION_LOCATION \
           --source=. \
           --runtime=python312 \
-          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=$_SECRET_JC_API_KEY_NAME,jc_org_id=$_SECRET_JC_ORG_ID_NAME,bucket_name=$_BUCKET_NAME,json_format=$_JSON_FORMAT \
+          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,bucket_name=${_RESOURCE_PREFIX}-di-bucket,json_format=$_JSON_FORMAT \
           --entry-point=jc_worker \
           --memory=$_WORKER_MEMORY \
-          --trigger-topic=$_PUBSUB_TOPIC \
+          --trigger-topic=${_RESOURCE_PREFIX}-jobs \
           --retry \
           --no-allow-unauthenticated \
           --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
 
         # 2. Get the auto-generated Pub/Sub Subscription
-        SUBSCRIPTION_PATH=$$(gcloud pubsub topics list-subscriptions $_PUBSUB_TOPIC | grep "projects/" | head -n 1)
+        SUBSCRIPTION_PATH=$$(gcloud pubsub topics list-subscriptions ${_RESOURCE_PREFIX}-jobs | grep "projects/" | head -n 1)
 
         # 3. Grant Pub/Sub Service Agent IAM permissions (Mandatory for DLQ)
         PROJECT_NUMBER=$$(gcloud projects describe $_GCP_PROJECT_ID_NAME --format="value(projectNumber)")
         PUBSUB_SERVICE_ACCOUNT="service-$$PROJECT_NUMBER@gcp-sa-pubsub.iam.gserviceaccount.com"
 
         # Permission to publish to the DLQ topic
-        gcloud pubsub topics add-iam-policy-binding $_PUBSUB_DLQ_TOPIC \
+        gcloud pubsub topics add-iam-policy-binding ${_RESOURCE_PREFIX}-jobs-dlq \
           --member="serviceAccount:$$PUBSUB_SERVICE_ACCOUNT" \
           --role="roles/pubsub.publisher"
 
@@ -115,46 +108,46 @@ steps:
 
         # 4. Attach the DLQ Redrive Policy
         gcloud pubsub subscriptions update $$SUBSCRIPTION_PATH \
-          --dead-letter-topic=$_PUBSUB_DLQ_TOPIC \
+          --dead-letter-topic=${_RESOURCE_PREFIX}-jobs-dlq \
           --max-delivery-attempts=5
           
         # 5. Create a Pull Subscription on the DLQ itself so messages aren't lost
-        gcloud pubsub subscriptions describe $_PUBSUB_DLQ_TOPIC-sub || gcloud pubsub subscriptions create $_PUBSUB_DLQ_TOPIC-sub --topic=$_PUBSUB_DLQ_TOPIC
+        gcloud pubsub subscriptions describe ${_RESOURCE_PREFIX}-jobs-dlq-sub || gcloud pubsub subscriptions create ${_RESOURCE_PREFIX}-jobs-dlq-sub --topic=${_RESOURCE_PREFIX}-jobs-dlq
 
   # Deploy the Redrive Cloud Function
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: bash
     args:
       - -c
       - |
         # 1. Deploy the HTTP Redrive function
-        gcloud functions deploy $_REDRIVE_FUNCTION_NAME \
+        gcloud functions deploy ${_RESOURCE_PREFIX}-redrive \
           --region=$_REGION_LOCATION \
           --source=. \
           --runtime=python312 \
-          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,dlq_sub_id=$_PUBSUB_DLQ_TOPIC-sub,main_topic_id=$_PUBSUB_TOPIC \
+          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,dlq_sub_id=${_RESOURCE_PREFIX}-jobs-dlq-sub,main_topic_id=${_RESOURCE_PREFIX}-jobs \
           --entry-point=redrive_dlq \
           --trigger-http \
           --no-allow-unauthenticated \
           --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
 
         # 2. Grant the service account permission to PULL from the DLQ subscription
-        gcloud pubsub subscriptions add-iam-policy-binding $_PUBSUB_DLQ_TOPIC-sub \
+        gcloud pubsub subscriptions add-iam-policy-binding ${_RESOURCE_PREFIX}-jobs-dlq-sub \
           --member="serviceAccount:$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" \
           --role="roles/pubsub.subscriber"
 
         # 3. Grant the service account permission to PUBLISH to the main topic
-        gcloud pubsub topics add-iam-policy-binding $_PUBSUB_TOPIC \
+        gcloud pubsub topics add-iam-policy-binding ${_RESOURCE_PREFIX}-jobs \
           --member="serviceAccount:$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" \
           --role="roles/pubsub.publisher"
 
   # Create a Cloud Scheduler job targeting the Orchestrator
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: bash
     args:
       - -c
       - |
         apt-get update && apt-get install -y jq
-        functionsURL=$$(gcloud functions describe $_ORCHESTRATOR_FUNCTION_NAME --region=$_REGION_LOCATION --format=json)
+        functionsURL=$$(gcloud functions describe ${_RESOURCE_PREFIX}-orchestrator --region=$_REGION_LOCATION --format=json)
         url=$$(echo "$$functionsURL" | jq -r '.url')
-        gcloud scheduler jobs create http $_SCHEDULE_NAME --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$$url" --http-method=GET --oidc-service-account-email="$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" || echo "Scheduler job may already exist."
+        gcloud scheduler jobs create http ${_RESOURCE_PREFIX}-schedule --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$$url" --http-method=GET --oidc-service-account-email="$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" || echo "Scheduler job may already exist."

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -7,9 +7,9 @@ substitutions:
   _RESOURCE_PREFIX: "jc-di"
   _SCHEDULE_CRON_TIME: "CHANGEVALUE" # Ref: https://crontab.guru/
   _GCP_PROJECT_ID_NAME: "CHANGEVALUE"
-  _JSON_FORMAT: "MultiLine" # MutiLine, SingleLine, NDJson
-  _STORAGE_CLASS: "standard"
-  _REGION_LOCATION: "us-central1"
+  _JSON_FORMAT: "CHANGEVALUE" # MutiLine, SingleLine, NDJson
+  _STORAGE_CLASS: "CHANGEVALUE" # Cloud Storage Class: standard, nearline, coldline, archive
+  _REGION_LOCATION: "CHANGEVALUE" # https://cloud.google.com/compute/docs/regions-zones
   _FORCE_RUN_DAYS: "30" # Change this when doing a force run test using the scheduler
   _MAX_EVENTS_PER_WORKER: "25000"
   _WORKER_MEMORY: "512MB"

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -158,12 +158,3 @@ steps:
         functionsURL=$$(gcloud functions describe $_ORCHESTRATOR_FUNCTION_NAME --region=$_REGION_LOCATION --format=json)
         url=$$(echo "$$functionsURL" | jq -r '.url')
         gcloud scheduler jobs create http $_SCHEDULE_NAME --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$$url" --http-method=GET --oidc-service-account-email="$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" || echo "Scheduler job may already exist."
-  # Create Scheduler Job
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: bash
-    args:
-      - -c
-      - |
-        apt-get update && apt-get install -y jq
-        url=$$(gcloud functions describe $_ORCHESTRATOR_FUNCTION_NAME --region=$_REGION_LOCATION --format="value(httpsTrigger.url)")
-        gcloud scheduler jobs create http $_SCHEDULE_NAME --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$$url" --http-method=GET --oidc-service-account-email="$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" || echo "Exists."

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -3,57 +3,44 @@ substitutions:
   _JC_ORG_ID: "CHANGEVALUE"
   _JC_SERVICE: "CHANGEVALUE"   # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services: 
   ### all, access_management, alerts, asset_management, directory, ldap, mdm, notifications, object_storage, password_manager, radius, reports, saas_app_management, software, sso, systems, workflows. ###
-
-  _JSON_FORMAT: "MultiLine"   # MutiLine, SingleLine, NDJson
-  _GCP_PROJECT_ID_NAME: "YOURPROJECTID" 
-  _STORAGE_CLASS: "standard" 
+  _SCHEDULE_CRON_TIME: "CHANGEVALUE"  # Ref: https://crontab.guru/
+  _GCP_PROJECT_ID_NAME: "CHANGEVALUE" 
   _BUCKET_NAME: "CHANGEVALUE"
+  _JSON_FORMAT: "MultiLine"   # MutiLine, SingleLine, NDJson
+  _STORAGE_CLASS: "standard" 
   _ORCHESTRATOR_FUNCTION_NAME: "jc-di-orchestrator" 
   _WORKER_FUNCTION_NAME: "jc-di-worker"
   _REDRIVE_FUNCTION_NAME: "jc-di-redrive" 
   _PUBSUB_TOPIC: "jc-di-jobs"
   _PUBSUB_DLQ_TOPIC: "jc-di-jobs-dlq" 
   _SCHEDULE_NAME: "jc-di-schedule" 
-  _SCHEDULE_CRON_TIME: "CHANGEVALUE"  # Ref: https://crontab.guru/
-  _REGION_LOCATION: "us-central1" # https://cloud.google.com/about/locations
+  _REGION_LOCATION: "us-central1" 
   _SECRET_JC_API_KEY_NAME: "jc-api-key" 
   _SECRET_JC_ORG_ID_NAME: "jc-org-id"
+  _FORCE_RUN_DAYS: "30" # Change this when doing a force run test using the scheduler
+  _MAX_EVENTS_PER_WORKER: "25000"
+  _WORKER_MEMORY: "512MB"
 
 steps:
-  # Step 1: Validate _JSON_FORMAT constraint
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
       - -c
       - |
         if [[ "$_JSON_FORMAT" != "MultiLine" && "$_JSON_FORMAT" != "SingleLine" && "$_JSON_FORMAT" != "NDJson" ]]; then
-          echo "FATAL ERROR: _JSON_FORMAT must be exactly 'MultiLine', 'SingleLine', or 'NDJson'."
-          echo "You provided: '$_JSON_FORMAT'"
           exit 1
         fi
-        echo "Validation passed. JSON format is set to: $_JSON_FORMAT"
 
-  # Step 2: Check and enable required Google Cloud services
+# Storage bucket creation
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
       - -c
       - |
-        gcloud services enable cloudbuild.googleapis.com cloudfunctions.googleapis.com \
-        cloudscheduler.googleapis.com storage-component.googleapis.com \
-        secretmanager.googleapis.com cloudresourcemanager.googleapis.com pubsub.googleapis.com
+        gsutil ls -p $_GCP_PROJECT_ID_NAME gs://$_BUCKET_NAME >/dev/null 2>&1 || \
+        gsutil mb -p $_GCP_PROJECT_ID_NAME -c $_STORAGE_CLASS -l $_REGION_LOCATION gs://$_BUCKET_NAME
 
-  # Step 3: Storage bucket creation
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: bash
-    args:
-      - -c
-      - |
-        if ! gsutil ls -p $_GCP_PROJECT_ID_NAME gs://$_BUCKET_NAME >/dev/null 2>&1; then
-          gsutil mb -p $_GCP_PROJECT_ID_NAME -c $_STORAGE_CLASS -l $_REGION_LOCATION gs://$_BUCKET_NAME
-        fi
-
-  # Step 4: Create Secrets in Secret Manager
+  # Create Secrets
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
@@ -62,7 +49,7 @@ steps:
         echo -n "$_JC_API_KEY" | gcloud secrets create $_SECRET_JC_API_KEY_NAME --data-file=- || true
         echo -n "$_JC_ORG_ID" | gcloud secrets create $_SECRET_JC_ORG_ID_NAME --data-file=- || true
 
-  # Step 5: Create Pub/Sub Topics (Main queue and DLQ)
+  # Create Pub/Sub Topics (Main queue and DLQ)
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
@@ -74,7 +61,7 @@ steps:
         # Create Dead Letter Topic
         gcloud pubsub topics describe $_PUBSUB_DLQ_TOPIC || gcloud pubsub topics create $_PUBSUB_DLQ_TOPIC
 
-  # Step 6: Deploy the Orchestrator Cloud Function (HTTP Triggered)
+  # Deploy the Orchestrator Cloud Function (HTTP Triggered)
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     args:
     - gcloud
@@ -84,13 +71,13 @@ steps:
     - --region=$_REGION_LOCATION
     - --source=.
     - --runtime=python312
-    - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=$_SECRET_JC_API_KEY_NAME,jc_org_id=$_SECRET_JC_ORG_ID_NAME,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=$_PUBSUB_TOPIC
+    - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=$_SECRET_JC_API_KEY_NAME,jc_org_id=$_SECRET_JC_ORG_ID_NAME,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=$_PUBSUB_TOPIC,force_run_days=$_FORCE_RUN_DAYS,max_events_per_worker=$_MAX_EVENTS_PER_WORKER
     - --entry-point=jc_orchestrator
     - --trigger-http
     - --no-allow-unauthenticated
     - --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
 
-  # Step 7: Deploy the Worker Cloud Function & Configure DLQ
+  # Deploy the Worker Cloud Function & Configure DLQ
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
@@ -103,6 +90,7 @@ steps:
           --runtime=python312 \
           --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=$_SECRET_JC_API_KEY_NAME,jc_org_id=$_SECRET_JC_ORG_ID_NAME,bucket_name=$_BUCKET_NAME,json_format=$_JSON_FORMAT \
           --entry-point=jc_worker \
+          --memory=$_WORKER_MEMORY \
           --trigger-topic=$_PUBSUB_TOPIC \
           --retry \
           --no-allow-unauthenticated \
@@ -133,7 +121,7 @@ steps:
         # 5. Create a Pull Subscription on the DLQ itself so messages aren't lost
         gcloud pubsub subscriptions describe $_PUBSUB_DLQ_TOPIC-sub || gcloud pubsub subscriptions create $_PUBSUB_DLQ_TOPIC-sub --topic=$_PUBSUB_DLQ_TOPIC
 
-  # Step 8: Deploy the Redrive Cloud Function
+  # Deploy the Redrive Cloud Function
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
@@ -160,7 +148,7 @@ steps:
           --member="serviceAccount:$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" \
           --role="roles/pubsub.publisher"
 
-  # Step 9: Create a Cloud Scheduler job targeting the Orchestrator
+  # Create a Cloud Scheduler job targeting the Orchestrator
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
@@ -170,3 +158,12 @@ steps:
         functionsURL=$$(gcloud functions describe $_ORCHESTRATOR_FUNCTION_NAME --region=$_REGION_LOCATION --format=json)
         url=$$(echo "$$functionsURL" | jq -r '.url')
         gcloud scheduler jobs create http $_SCHEDULE_NAME --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$$url" --http-method=GET --oidc-service-account-email="$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" || echo "Scheduler job may already exist."
+  # Create Scheduler Job
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        apt-get update && apt-get install -y jq
+        url=$$(gcloud functions describe $_ORCHESTRATOR_FUNCTION_NAME --region=$_REGION_LOCATION --format="value(httpsTrigger.url)")
+        gcloud scheduler jobs create http $_SCHEDULE_NAME --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$$url" --http-method=GET --oidc-service-account-email="$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" || echo "Exists."

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,41 +1,37 @@
 substitutions:
-  # Note: No quotations needed for the variable values, except for _SCHEDULE_CRON_TIME and _GCP_PROJECT_ID_NAME
+  _JC_API_KEY: "CHANGEVALUE"
+  _JC_ORG_ID: "CHANGEVALUE"
+  _JC_SERVICE: "CHANGEVALUE"   # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services: 
+  ### all, access_management, alerts, asset_management, directory, ldap, mdm, notifications, object_storage, password_manager, radius, reports, saas_app_management, software, sso, systems, workflows. ###
 
-  _JC_API_KEY: CHANGEVALUE # JC API key
-  _JC_ORG_ID: CHANGEVALUE # JC ORG id
-  # JC Services: directory, radius, sso, systems, ldap, mdm
-  # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services: alerts, all, directory, ldap, mdm, object_storage, password_manager, radius, reports, saas_app_management, software, sso, systems, and access_management.
-  _JC_SERVICE: CHANGEVALUE
-  _GCP_PROJECT_ID_NAME: "CHANGEVALUE" # GCP project Id
-  _GCP_PROJECT_ID_NUMBER: "CHANGEVALUE" # GCP project Id Number
-  _STORAGE_CLASS: CHANGEVALUE # Cloud Storage Class: standard, nearline, coldline, archive
-  _BUCKET_NAME: CHANGEVALUE # Cloud Storage Bucket Name. Must be unique
-  _FUNCTION_NAME: CHANGEVALUE # Cloud Functions Name
-  _SCHEDULE_NAME: CHANGEVALUE # Cloud Scheduler Name
-  _SCHEDULE_CRON_TIME: "CHANGEVALUE" # Check here: https://crontab.guru/
-  _REGION_LOCATION: CHANGEVALUE # https://cloud.google.com/compute/docs/regions-zones
-  _SECRET_JC_API_KEY_NAME: CHANGEVALUE # Secret Manager JCAPIKEY Name
-  _SECRET_JC_ORG_ID_NAME: CHANGEVALUE # # Secret Manager JCORGID Name
-
+  _JSON_FORMAT: "MultiLine"   # MutiLine, SingleLine, NDJson
+  _GCP_PROJECT_ID_NAME: "YOURPROJECTID" 
+  _STORAGE_CLASS: "standard" 
+  _BUCKET_NAME: "CHANGEVALUE"
+  _ORCHESTRATOR_FUNCTION_NAME: "jc-di-orchestrator" 
+  _WORKER_FUNCTION_NAME: "jc-di-worker"
+  _REDRIVE_FUNCTION_NAME: "jc-di-redrive" 
+  _PUBSUB_TOPIC: "jc-di-jobs"
+  _PUBSUB_DLQ_TOPIC: "jc-di-jobs-dlq" 
+  _SCHEDULE_NAME: "jc-di-schedule" 
+  _SCHEDULE_CRON_TIME: "CHANGEVALUE"  # Ref: https://crontab.guru/
+  _REGION_LOCATION: "us-central1" # https://cloud.google.com/about/locations
+  _SECRET_JC_API_KEY_NAME: "jc-api-key" 
+  _SECRET_JC_ORG_ID_NAME: "jc-org-id"
 
 steps:
-  # Step 0: Validate Google Cloud project ID
+  # Step 1: Validate _JSON_FORMAT constraint
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
       - -c
       - |
-        # Check if the project exists and retrieve details
-        gcloud projects describe '$_GCP_PROJECT_ID_NUMBER'
-  
-  #Step 1: Validate Google Cloud project ID Name
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: bash
-    args:
-      - -c
-      - |
-        # Check if the project exists and retrieve details
-        gcloud projects describe '$_GCP_PROJECT_ID_NAME'
+        if [[ "$_JSON_FORMAT" != "MultiLine" && "$_JSON_FORMAT" != "SingleLine" && "$_JSON_FORMAT" != "NDJson" ]]; then
+          echo "FATAL ERROR: _JSON_FORMAT must be exactly 'MultiLine', 'SingleLine', or 'NDJson'."
+          echo "You provided: '$_JSON_FORMAT'"
+          exit 1
+        fi
+        echo "Validation passed. JSON format is set to: $_JSON_FORMAT"
 
   # Step 2: Check and enable required Google Cloud services
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -43,65 +39,134 @@ steps:
     args:
       - -c
       - |
-        if ! gcloud services list --enabled | grep -q "cloudbuild.googleapis.com"; then
-          gcloud services enable cloudbuild.googleapis.com
-        fi
-        if ! gcloud services list --enabled | grep -q "cloudfunctions.googleapis.com"; then
-          gcloud services enable cloudfunctions.googleapis.com
-        fi
-        if ! gcloud services list --enabled | grep -q "cloudscheduler.googleapis.com"; then
-          gcloud services enable cloudscheduler.googleapis.com
-        fi
-        if ! gcloud services list --enabled | grep -q "storage-component.googleapis.com"; then
-          gcloud services enable storage-component.googleapis.com
-        fi
-        if ! gcloud services list --enabled | grep -q "secretmanager.googleapis.com"; then
-          gcloud services enable secretmanager.googleapis.com
-        fi
-        if ! gcloud services list --enabled | grep -q "cloudresourcemanager.googleapis.com"; then
-          gcloud services enable cloudresourcemanager.googleapis.com
-        fi
+        gcloud services enable cloudbuild.googleapis.com cloudfunctions.googleapis.com \
+        cloudscheduler.googleapis.com storage-component.googleapis.com \
+        secretmanager.googleapis.com cloudresourcemanager.googleapis.com pubsub.googleapis.com
 
   # Step 3: Storage bucket creation
-  # Create a Storage bucket
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    args: ['gsutil', 'mb', '-p', '$_GCP_PROJECT_ID_NAME', '-c', '$_STORAGE_CLASS', '-l', '$_REGION_LOCATION', 'gs://$_BUCKET_NAME']
-
-  #Step 4: Create Secrets in Secret Manager
-  #Create secret keys for JCAPIKEY and JCORGID
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
       - -c
       - |
-        printf "$_JC_API_KEY" | gcloud secrets create $_SECRET_JC_API_KEY_NAME --data-file=-
-        printf "$_JC_ORG_ID" | gcloud secrets create $_SECRET_JC_ORG_ID_NAME --data-file=-
+        if ! gsutil ls -p $_GCP_PROJECT_ID_NAME gs://$_BUCKET_NAME >/dev/null 2>&1; then
+          gsutil mb -p $_GCP_PROJECT_ID_NAME -c $_STORAGE_CLASS -l $_REGION_LOCATION gs://$_BUCKET_NAME
+        fi
 
-  #Step 5: Create a Cloud Run Functions
-  # Deploy the script to Google Cloud Run Functions(2nd gen) as an HTTP trigger
+  # Step 4: Create Secrets in Secret Manager
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        echo -n "$_JC_API_KEY" | gcloud secrets create $_SECRET_JC_API_KEY_NAME --data-file=- || true
+        echo -n "$_JC_ORG_ID" | gcloud secrets create $_SECRET_JC_ORG_ID_NAME --data-file=- || true
+
+  # Step 5: Create Pub/Sub Topics (Main queue and DLQ)
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        # Create Main Topic
+        gcloud pubsub topics describe $_PUBSUB_TOPIC || gcloud pubsub topics create $_PUBSUB_TOPIC
+        
+        # Create Dead Letter Topic
+        gcloud pubsub topics describe $_PUBSUB_DLQ_TOPIC || gcloud pubsub topics create $_PUBSUB_DLQ_TOPIC
+
+  # Step 6: Deploy the Orchestrator Cloud Function (HTTP Triggered)
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     args:
     - gcloud
     - functions
     - deploy
-    - $_FUNCTION_NAME
+    - $_ORCHESTRATOR_FUNCTION_NAME
     - --region=$_REGION_LOCATION
     - --source=.
-    - --runtime=python39
-    - --set-secrets=jc_api_key=$_SECRET_JC_API_KEY_NAME:latest,jc_org_id=$_SECRET_JC_ORG_ID_NAME:latest
-    - --set-env-vars=cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,bucket_name=$_BUCKET_NAME
-    - --entry-point=run_di
+    - --runtime=python312
+    - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=$_SECRET_JC_API_KEY_NAME,jc_org_id=$_SECRET_JC_ORG_ID_NAME,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=$_PUBSUB_TOPIC
+    - --entry-point=jc_orchestrator
     - --trigger-http
+    - --no-allow-unauthenticated
     - --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
 
-  # # Step 6: Create a Cloud Scheduler job
+  # Step 7: Deploy the Worker Cloud Function & Configure DLQ
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        # 1. Deploy the function
+        gcloud functions deploy $_WORKER_FUNCTION_NAME \
+          --region=$_REGION_LOCATION \
+          --source=. \
+          --runtime=python312 \
+          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=$_SECRET_JC_API_KEY_NAME,jc_org_id=$_SECRET_JC_ORG_ID_NAME,bucket_name=$_BUCKET_NAME,json_format=$_JSON_FORMAT \
+          --entry-point=jc_worker \
+          --trigger-topic=$_PUBSUB_TOPIC \
+          --retry \
+          --no-allow-unauthenticated \
+          --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
+
+        # 2. Get the auto-generated Pub/Sub Subscription
+        SUBSCRIPTION_PATH=$$(gcloud pubsub topics list-subscriptions $_PUBSUB_TOPIC | grep "projects/" | head -n 1)
+
+        # 3. Grant Pub/Sub Service Agent IAM permissions (Mandatory for DLQ)
+        PROJECT_NUMBER=$$(gcloud projects describe $_GCP_PROJECT_ID_NAME --format="value(projectNumber)")
+        PUBSUB_SERVICE_ACCOUNT="service-$$PROJECT_NUMBER@gcp-sa-pubsub.iam.gserviceaccount.com"
+
+        # Permission to publish to the DLQ topic
+        gcloud pubsub topics add-iam-policy-binding $_PUBSUB_DLQ_TOPIC \
+          --member="serviceAccount:$$PUBSUB_SERVICE_ACCOUNT" \
+          --role="roles/pubsub.publisher"
+
+        # Permission to acknowledge messages on the main subscription
+        gcloud pubsub subscriptions add-iam-policy-binding $$SUBSCRIPTION_PATH \
+          --member="serviceAccount:$$PUBSUB_SERVICE_ACCOUNT" \
+          --role="roles/pubsub.subscriber"
+
+        # 4. Attach the DLQ Redrive Policy
+        gcloud pubsub subscriptions update $$SUBSCRIPTION_PATH \
+          --dead-letter-topic=$_PUBSUB_DLQ_TOPIC \
+          --max-delivery-attempts=5
+          
+        # 5. Create a Pull Subscription on the DLQ itself so messages aren't lost
+        gcloud pubsub subscriptions describe $_PUBSUB_DLQ_TOPIC-sub || gcloud pubsub subscriptions create $_PUBSUB_DLQ_TOPIC-sub --topic=$_PUBSUB_DLQ_TOPIC
+
+  # Step 8: Deploy the Redrive Cloud Function
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        # 1. Deploy the HTTP Redrive function
+        gcloud functions deploy $_REDRIVE_FUNCTION_NAME \
+          --region=$_REGION_LOCATION \
+          --source=. \
+          --runtime=python312 \
+          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,dlq_sub_id=$_PUBSUB_DLQ_TOPIC-sub,main_topic_id=$_PUBSUB_TOPIC \
+          --entry-point=redrive_dlq \
+          --trigger-http \
+          --no-allow-unauthenticated \
+          --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
+
+        # 2. Grant the service account permission to PULL from the DLQ subscription
+        gcloud pubsub subscriptions add-iam-policy-binding $_PUBSUB_DLQ_TOPIC-sub \
+          --member="serviceAccount:$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" \
+          --role="roles/pubsub.subscriber"
+
+        # 3. Grant the service account permission to PUBLISH to the main topic
+        gcloud pubsub topics add-iam-policy-binding $_PUBSUB_TOPIC \
+          --member="serviceAccount:$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" \
+          --role="roles/pubsub.publisher"
+
+  # Step 9: Create a Cloud Scheduler job targeting the Orchestrator
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: bash
     args:
       - -c
       - |
         apt-get update && apt-get install -y jq
-        functionsURL=$(gcloud functions describe $_FUNCTION_NAME --region=$_REGION_LOCATION --format=json)
-        url=$(echo "$functionsURL" | jq -r '.url')
-        echo "URL: $url"
-        gcloud scheduler jobs create http $_SCHEDULE_NAME --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$url" --http-method=GET --oidc-service-account-email="$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com"
+        functionsURL=$$(gcloud functions describe $_ORCHESTRATOR_FUNCTION_NAME --region=$_REGION_LOCATION --format=json)
+        url=$$(echo "$$functionsURL" | jq -r '.url')
+        gcloud scheduler jobs create http $_SCHEDULE_NAME --location=$_REGION_LOCATION --schedule="$_SCHEDULE_CRON_TIME" --uri="$$url" --http-method=GET --oidc-service-account-email="$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com" || echo "Scheduler job may already exist."

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -56,24 +56,15 @@ def get_secret(project_id, secret_name):
         raise Exception(e)
 
 def get_cron_time(cron_expression, time_tolerance):
-    """Checks the schedule, with GCP 'Force Run' detection."""
+    """Calculates the current and previous cron execution times."""
     now = datetime.datetime.now(datetime.timezone.utc)
     try:
         cron_time = croniter(cron_expression, now + datetime.timedelta(seconds=time_tolerance))
         current_cron_time = cron_time.get_prev(datetime.datetime)
         previous_cron_time = cron_time.get_prev(datetime.datetime)
-        
-        # GCP "Force Run" Detection
-        if (now - current_cron_time).total_seconds() > 60: 
-            # Grab the requested lookback window from the environment (defaults to 30 days). This functionality is used for testing. Change the force_run_days value on the orchestrator function env variables (max 90 days) 
-            force_days = int(os.environ.get('force_run_days', 30))
-            
-            print(f"Manual Force Run detected! Adjusting search window to exactly {force_days} days from right now.")
-            
-            force_run_start_time = now - datetime.timedelta(days=force_days) 
-            return now, force_run_start_time
             
         return current_cron_time, previous_cron_time
+        
     except Exception as e:
         print(f"Error in cron expression '{cron_expression}': {e}")
         raise Exception(e)
@@ -100,6 +91,15 @@ def jc_orchestrator(request):
         print(f"Missing env var: {e}")
         return f"Missing env var: {e}", 500
 
+    # --- Check for manual test payload from GCP Console ---
+    request_json = request.get_json(silent=True) or {}
+    test_event_days = request_json.get('event_days')
+    test_service = request_json.get('service')
+
+    if test_service:
+        print(f"[TEST MODE] Overriding default service with: {test_service}")
+        service_env = test_service
+
     print("Fetching API Key from Secret Manager...")
     jcapikey = get_secret(project_id, jc_api_key_secret_name)
     
@@ -111,8 +111,24 @@ def jc_orchestrator(request):
             jc_org_id = fetched_id
             print(f"Org ID loaded")
 
-    time_tolerance = 10
-    now, previous_time = get_cron_time(cron_schedule, time_tolerance)
+    # --- Determine Time Window (Test Payload vs Cron Schedule) ---
+    if test_event_days:
+        # Test Mode: Use the provided days back
+        print(f"[TEST MODE] 'event_days' payload detected. Calculating window for the past {test_event_days} days.")
+        try:
+            days_back = int(test_event_days)
+            now = datetime.datetime.now(datetime.timezone.utc)
+            previous_time = now - datetime.timedelta(days=days_back)
+        except ValueError:
+            error_msg = "Invalid 'event_days' value. Must be a whole number (integer)."
+            print(error_msg)
+            return error_msg, 400
+            
+    else:
+        # Production Mode: Normal Cron Run
+        time_tolerance = 10
+        now, previous_time = get_cron_time(cron_schedule, time_tolerance)
+        
     print(f"Search Window: {previous_time} to {now}")
     
     publisher = pubsub_v1.PublisherClient()
@@ -196,6 +212,7 @@ def jc_orchestrator(request):
 
     print("--- ORCHESTRATOR COMPLETE ---")
     return "Orchestration complete", 200
+
 # ==============================================================================
 # WORKER FUNCTION (Triggered by Pub/Sub)
 # ==============================================================================

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -363,7 +363,7 @@ def redrive_dlq(request):
                 request={"subscription": subscription_path, "ack_ids": ack_ids}
             )
             
-        result_message = f"🏁 Successfully redelivered {moved_count} messages to {main_topic_id}!"
+        result_message = f"Successfully redelivered {moved_count} messages to {main_topic_id}!"
         print(result_message)
         
         return (result_message, 200)

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -65,7 +65,7 @@ def get_cron_time(cron_expression, time_tolerance):
         
         # GCP "Force Run" Detection
         if (now - current_cron_time).total_seconds() > 60: 
-            # Grab the requested lookback window from the environment (defaults to 30 days). This functionality is used for testing. Change the number value on how many event days you'd like to pull (max 90 days) 
+            # Grab the requested lookback window from the environment (defaults to 30 days). This functionality is used for testing. Change the force_run_days value on the orchestrator function env variables (max 90 days) 
             force_days = int(os.environ.get('force_run_days', 30))
             
             print(f"Manual Force Run detected! Adjusting search window to exactly {force_days} days from right now.")
@@ -133,7 +133,11 @@ def jc_orchestrator(request):
     if jc_org_id != '':                 
         headers['x-org-id'] = jc_org_id
 
-    MAX_EVENTS_PER_WORKER = 25000
+    # Grab the max events from the environment, defaulting to 25000 if not set
+    MAX_EVENTS_PER_WORKER = int(os.environ.get('max_events_per_worker', 25000)) 
+
+    # Create a list to track all of our Pub/Sub publish operations
+    publish_futures = []
 
     for service in service_list:
         if service not in available_services:
@@ -173,13 +177,26 @@ def jc_orchestrator(request):
                 'start_time': slice_start.isoformat("T").replace("+00:00", "Z"),
                 'end_time': slice_end.isoformat("T").replace("+00:00", "Z")
             }
-            # Publish to Pub/Sub
-            publisher.publish(topic_path, json.dumps(message_body).encode("utf-8"))
+            
+            # Publish to Pub/Sub and capture the Future object it returns
+            future = publisher.publish(topic_path, json.dumps(message_body).encode("utf-8"))
+            publish_futures.append(future)
+            
             print(f"Queued job into Pub/Sub: {service} | {message_body['start_time']} to {message_body['end_time']}")
 
-    print("--- ORCHESTRATOR COMPLETE ---")
-    return "Orchestration complete", 200 # Should return 200 everytime even when we can't communicate to the JC API. It should always return event times to be pushed to the worker
+    # Wait for all messages to be successfully published before exiting the function
+    if publish_futures:
+        print(f"Waiting for {len(publish_futures)} Pub/Sub messages to finish sending...")
+        for future in publish_futures:
+            try:
+                # Calling .result() forces the code to pause until this specific message is confirmed delivered
+                future.result() 
+            except Exception as e:
+                print(f"Failed to publish message to Pub/Sub: {e}")
+                raise Exception(f"Pub/Sub publish failed: {e}")
 
+    print("--- ORCHESTRATOR COMPLETE ---")
+    return "Orchestration complete", 200
 # ==============================================================================
 # WORKER FUNCTION (Triggered by Pub/Sub)
 # ==============================================================================
@@ -208,12 +225,6 @@ def jc_worker(event, context):
     pubsub_message = base64.b64decode(event['data']).decode('utf-8')
     payload = json.loads(pubsub_message)
     print(f"Received Job Payload: {payload}")
-    
-    service = payload['service']
-    start_date = payload['start_time']
-    end_date = payload['end_time']
-    
-    url = "https://api.jumpcloud.com/insights/directory/v1/events"
     
     service = payload['service']
     start_date = payload['start_time']

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -1,124 +1,373 @@
-from croniter import croniter
-import datetime
-import json
 import os
+import json
 import requests
+import gzip
+import logging
+import datetime
+import math
+import base64
+import re
+from croniter import croniter
+from google.cloud import secretmanager
+from google.cloud import pubsub_v1
 from google.cloud import storage
 
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
-def jc_directory_insights():
-    print("########### JC Directory Insights Function Started ###########")
-    try:
-        jc_api_key = os.environ['jc_api_key']
-        jc_org_id = os.environ['jc_org_id']
-        cron_schedule = os.environ['cron_schedule']
-        service =  os.environ['service']
-        bucket_name = os.environ['bucket_name']
+# ==============================================================================
+# BIGQUERY SANITIZATION UTILITIES
+# ==============================================================================
+def sanitize_key(key):
+    """Replaces characters that are invalid in BigQuery column names."""
+    clean_key = re.sub(r'[^a-zA-Z0-9_]', '_', key)
+    # BigQuery columns cannot start with a number
+    if clean_key and clean_key[0].isdigit():
+        clean_key = '_' + clean_key
+    return clean_key
 
-    except KeyError as e:
-        raise Exception(e)
-    
-    now = datetime.datetime.utcnow()
-    print(f'Cron Expression: {cron_schedule}')
-    time_tolerance = 10
+def sanitize_payload(data):
+    """Recursively cleans JSON for BigQuery compatibility."""
+    if isinstance(data, dict):
+        # Convert empty dicts to None (null) to prevent BQ "Unsupported empty struct" errors
+        if not data:
+            return None
+        return {sanitize_key(k): sanitize_payload(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        # Convert empty lists to None
+        if not data:
+            return None
+        return [sanitize_payload(item) for item in data]
+    else:
+        return data
+
+# ==============================================================================
+# CORE HELPER FUNCTIONS
+# ==============================================================================
+def get_secret(project_id, secret_name):
+    """Retrieves the secret value from GCP Secret Manager."""
+    client = secretmanager.SecretManagerServiceClient()
+    name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
     try:
-        cron_time = croniter(cron_schedule, now - datetime.timedelta(seconds=time_tolerance))  # get the previous time with 59 seconds of tolerance
-        now = cron_time.get_next(datetime.datetime)  # get the next run time from that previous time.
-        start_dt = cron_time.get_prev(datetime.datetime)  # get the previous run time        
-        print(f'Current Cron Time: {now}')
-        print(f'Previous Cron Time: {start_dt}')
-        # time_diff = abs((now - previous_cron_time).total_seconds())
+        response = client.access_secret_version(request={"name": name})
+        return response.payload.data.decode("UTF-8")
     except Exception as e:
-        print(f"Error in cron expression: {e}")
-        # Exit the code and raise a
+        print(f"Error retrieving secret {secret_name}: {e}")
+        raise Exception(e)
 
-    now_seconds = now.second
-    start_date = start_dt.isoformat("T") + "Z"
-    end_date = now.isoformat("T") + "Z"
-    
-    # If the cronTime is not within the tolerance, error out
-    if now_seconds >= time_tolerance:
-        # Timestamps of the cron schedule
-        print(f'Timestamps of the cron schedule: {start_date}, {end_date}')
-        # Print an instruction to run the powershell script manually and save it to the S3 bucket
-        print(f"Please run the powershell script manually and save it to the Storage bucket: {bucket_name}")
-        print(f'service: {service},\n start-date: {start_date},\n end-date: {end_date},\n *** Powershell Script *** \n $sourcePath =  "<directory_path>/jc_directoryinsights_{start_date}_{end_date}.json" \n Get-JCEvent -service {service} -start_date {start_date} -EndTime {end_date} | ConvertTo-Json -Depth 99 | Out-File -FilePath $sourcePath \n $newFileName = "$($sourcePath).gz" \n $srcFileStream = New-Object System.IO.FileStream($sourcePath,([IO.FileMode]::Open),([IO.FileAccess]::Read),([IO.FileShare]::Read)) \n $dstFileStream = New-Object System.IO.FileStream($newFileName,([IO.FileMode]::Create),([IO.FileAccess]::Write),([IO.FileShare]::None)) \n $gzip = New-Object System.IO.Compression.GZipStream($dstFileStream,[System.IO.Compression.CompressionLevel]::SmallestSize) \n $srcFileStream.CopyTo($gzip) \n $gzip.Dispose() \n $srcFileStream.Dispose() \n $dstFileStream.Dispose()\n *** End Script ***' )
+def get_cron_time(cron_expression, time_tolerance):
+    """Checks the schedule, with GCP 'Force Run' detection."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    try:
+        cron_time = croniter(cron_expression, now + datetime.timedelta(seconds=time_tolerance))
+        current_cron_time = cron_time.get_prev(datetime.datetime)
+        previous_cron_time = cron_time.get_prev(datetime.datetime)
+        
+        # GCP "Force Run" Detection
+        if (now - current_cron_time).total_seconds() > 60: 
+            # Grab the requested lookback window from the environment (defaults to 30 days). This functionality is used for testing. Change the number value on how many event days you'd like to pull (max 90 days) 
+            force_days = int(os.environ.get('force_run_days', 30))
+            
+            print(f"Manual Force Run detected! Adjusting search window to exactly {force_days} days from right now.")
+            
+            force_run_start_time = now - datetime.timedelta(days=force_days) 
+            return now, force_run_start_time
+            
+        return current_cron_time, previous_cron_time
+    except Exception as e:
+        print(f"Error in cron expression '{cron_expression}': {e}")
+        raise Exception(e)
 
-        raise Exception("Cron time is not within the tolerance.") # This will exit the code
+def chunk_time_range(start_time, end_time, chunks):
+    """Splits a time range into an array of smaller time ranges."""
+    delta = (end_time - start_time) / chunks
+    return [(start_time + delta * i, start_time + delta * (i + 1)) for i in range(chunks)]
+
+# ==============================================================================
+# ORCHESTRATOR FUNCTION (Triggered by HTTP via Cloud Scheduler)
+# ==============================================================================
+def jc_orchestrator(request):
+    print("--- ORCHESTRATOR STARTED ---")
+    try:
+        project_id = os.environ['gcp_project_id']
+        jc_api_key_secret_name = os.environ['jc_api_key_secret']
+        jc_org_id_secret_name = os.environ.get('jc_org_id', '') 
+        cron_schedule = os.environ['cron_schedule']
+        topic_name = os.environ['pubsub_topic']
+        service_env = os.environ['service']
+        print("Environment variables loaded successfully.")
+    except KeyError as e:
+        print(f"Missing env var: {e}")
+        return f"Missing env var: {e}", 500
+
+    print("Fetching API Key from Secret Manager...")
+    jcapikey = get_secret(project_id, jc_api_key_secret_name)
     
-    print(f'start_date: {start_date}, end_date: {end_date}')
-    available_services = ['all','alerts','directory','password_manager','sso','radius','systems','software','mdm','object_storage','saas_app_management','access_management']
+    jc_org_id = "" 
+    if jc_org_id_secret_name:
+        print("Fetching Org ID from Secret Manager...")
+        fetched_id = get_secret(project_id, jc_org_id_secret_name).strip()
+        if fetched_id:
+            jc_org_id = fetched_id
+            print(f"Org ID loaded: {jc_org_id}")
+
+    time_tolerance = 10
+    now, previous_time = get_cron_time(cron_schedule, time_tolerance)
+    print(f"Search Window: {previous_time} to {now}")
     
-    service_list = ((service.replace(" ", "")).lower()).split(",")
+    publisher = pubsub_v1.PublisherClient()
+    topic_path = publisher.topic_path(project_id, topic_name)
+    
+    available_services = ['all', 'access_management', 'alerts', 'asset_management', 'directory', 'ldap', 'mdm', 'notifications', 'object_storage', 'password_manager', 'radius', 'reports', 'saas_app_management', 'software', 'sso', 'systems', 'workflows']
+    service_list = ((service_env.replace(" ", "")).lower()).split(",")
+    
+    if 'all' in service_list and len(service_list) > 1:
+        print("Configuration contains 'all' alongside specific services. Defaulting to 'all'.")
+        service_list = ['all']
+    
+    headers = {
+        'x-api-key': jcapikey,
+        'content-type': "application/json",
+        'user-agent': "JumpCloud_GCPServerless.DirectoryInsights/3.0.0"
+    }
+    if jc_org_id != '':                 
+        headers['x-org-id'] = jc_org_id
+
+    MAX_EVENTS_PER_WORKER = 25000
+
     for service in service_list:
         if service not in available_services:
-            raise Exception(f"Unknown service: {service}")
-    if 'all' in service_list and len(service_list) > 1:
-        raise Exception(f"Error - Service List contains 'all' and additional services : {service_list}")
+            print(f"Unknown service: {service}")
+            continue
+
+        start_iso = previous_time.isoformat("T").replace("+00:00", "Z")
+        end_iso = now.isoformat("T").replace("+00:00", "Z")
+        
+        count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
+        
+        # Omit the service parameter if querying 'all' to prevent 400 Bad Request
+        count_body = {'service': [service], 'start_time': start_iso, 'end_time': end_iso}
+        
+        print(f"[ORCHESTRATOR] Querying Count URL: {count_url} | Service: {service}")
+        print(f"[ORCHESTRATOR] Payload: {count_body}")
+        try:
+            response = requests.post(count_url, json=count_body, headers=headers)
+            response.raise_for_status()
+            total_events = json.loads(response.text).get('count', 0)
+            print(f"Total events found for {service}: {total_events}")
+        except Exception as e:
+            print(f"Failed to get event count for {service}. Defaulting to full slice. Error: {e}")
+            total_events = MAX_EVENTS_PER_WORKER 
+        
+        if total_events == 0:
+            print(f"No events for {service} between {start_iso} and {end_iso}. Skipping.")
+            continue 
+
+        num_chunks = max(1, math.ceil(total_events / MAX_EVENTS_PER_WORKER))
+        time_slices = chunk_time_range(previous_time, now, num_chunks)
+        print(f"Splitting {service} into {num_chunks} chunk(s) for the workers.")
+        
+        for slice_start, slice_end in time_slices:
+            message_body = {
+                'service': service,
+                'start_time': slice_start.isoformat("T").replace("+00:00", "Z"),
+                'end_time': slice_end.isoformat("T").replace("+00:00", "Z")
+            }
+            # Publish to Pub/Sub
+            publisher.publish(topic_path, json.dumps(message_body).encode("utf-8"))
+            print(f"Queued job into Pub/Sub: {service} | {message_body['start_time']} to {message_body['end_time']}")
+
+    print("--- ORCHESTRATOR COMPLETE ---")
+    return "Orchestration complete", 200 # Should return 200 everytime even when we can't communicate to the JC API. It should always return event times to be pushed to the worker
+
+# ==============================================================================
+# WORKER FUNCTION (Triggered by Pub/Sub)
+# ==============================================================================
+def jc_worker(event, context):
+    print("--- WORKER STARTED ---")
+    try:
+        project_id = os.environ['gcp_project_id']
+        jc_api_key_secret_name = os.environ['jc_api_key_secret']
+        bucket_name = os.environ['bucket_name']
+        jc_org_id_secret_name = os.environ.get('jc_org_id', '')
+        json_format = os.environ.get('json_format', 'MultiLine') # MultiLine, SingleLine, or NDJson
+    except KeyError as e:
+        print(f"Missing environment variable: {e}")
+        raise Exception(e)
+
+    print("Worker fetching API Key from Secret Manager...")
+    jcapikey = get_secret(project_id, jc_api_key_secret_name)
+    
+    jc_org_id = "" 
+    if jc_org_id_secret_name:
+        fetched_id = get_secret(project_id, jc_org_id_secret_name).strip()
+        if fetched_id:
+            jc_org_id = fetched_id
+
+    # Decode Pub/Sub message
+    pubsub_message = base64.b64decode(event['data']).decode('utf-8')
+    payload = json.loads(pubsub_message)
+    print(f"Received Job Payload: {payload}")
+    
+    service = payload['service']
+    start_date = payload['start_time']
+    end_date = payload['end_time']
+    
+    url = "https://api.jumpcloud.com/insights/directory/v1/events"
+    
+    service = payload['service']
+    start_date = payload['start_time']
+    end_date = payload['end_time']
+    
+    url = "https://api.jumpcloud.com/insights/directory/v1/events"
+    body = {
+        'service': [service],
+        'start_time': start_date,
+        'end_time': end_date,
+        "limit": 10000
+    }
+    
+    headers = {
+        'x-api-key': jcapikey,
+        'content-type': "application/json",
+        'user-agent': "JumpCloud_GCPServerless.DirectoryInsights/3.0.0"
+    }
+    if jc_org_id != '':
+        headers['x-org-id'] = jc_org_id
+        
     final_data = []
     
-    if len(service_list) > 1:
-        for service in service_list:
-            print (f'service: {service},\n start-date: {start_date},\n end-date: {end_date},\n *** Powershell Script *** \n $sourcePath =  "<directory_path>/jc_directoryinsights_{start_date}_{end_date}.json" \n Get-JCEvent -service {service} -StartTime {start_date} -EndTime {end_date} | ConvertTo-Json -Depth 99 | Out-File -FilePath $sourcePath \n $newFileName = "$($sourcePath).gz" \n $srcFileStream = New-Object System.IO.FileStream($sourcePath,([IO.FileMode]::Open),([IO.FileAccess]::Read),([IO.FileShare]::Read)) \n $dstFileStream = New-Object System.IO.FileStream($newFileName,([IO.FileMode]::Create),([IO.FileAccess]::Write),([IO.FileShare]::None)) \n $gzip = New-Object System.IO.Compression.GZipStream($dstFileStream,[System.IO.Compression.CompressionLevel]::SmallestSize) \n $srcFileStream.CopyTo($gzip) \n $gzip.Dispose() \n $srcFileStream.Dispose() \n $dstFileStream.Dispose()\n *** End Script ***' )
-    else: 
-        for service in service_list:
-            print (f'service: {service},\n start-date: {start_date},\n end-date: {end_date},\n *** Powershell Script *** \n $sourcePath =  "<directory_path>/jc_directoryinsights_{start_date}_{end_date}.json" \n Get-JCEvent -service {service} -StartTime {start_date} -EndTime {end_date} | ConvertTo-Json -Depth 99 | Out-File -FilePath $sourcePath \n $newFileName = "$($sourcePath).gz" \n $srcFileStream = New-Object System.IO.FileStream($sourcePath,([IO.FileMode]::Open),([IO.FileAccess]::Read),([IO.FileShare]::Read)) \n $dstFileStream = New-Object System.IO.FileStream($newFileName,([IO.FileMode]::Create),([IO.FileAccess]::Write),([IO.FileShare]::None)) \n $gzip = New-Object System.IO.Compression.GZipStream($dstFileStream,[System.IO.Compression.CompressionLevel]::SmallestSize) \n $srcFileStream.CopyTo($gzip) \n $gzip.Dispose() \n $srcFileStream.Dispose() \n $dstFileStream.Dispose()\n *** End Script ***')
-        
-    for service in service_list:
-        url = "https://api.jumpcloud.com/insights/directory/v1/events"
-        body = {
-            'service': [f"{service}"],
-            'start_time': start_date,
-            'end_time': end_date,
-            "limit": 10000
-        }
-        headers = {
-            'x-api-key': jc_api_key,
-            'content-type': "application/json",
-            'user-agent': 'JumpCloud_GCPServerless.DirectoryInsights/0.0.1'
-        }
-        if jc_org_id != '':
-            headers['x-org-id'] = jc_org_id
+    print(f"[WORKER] Querying Events URL: {url}")
+    print(f"[WORKER] Payload: {body}")
+    
+    try:
         response = requests.post(url, json=body, headers=headers)
-
-        try:
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            raise Exception(e)
-
-        response_body = json.loads(response.text)
-        data = response_body
-        while response.headers["X-Result-Count"] >= response.headers["X-Limit"]:
-            body["search_after"] = json.loads(response.headers["X-Search_After"])
-            response = requests.post(url, json=body, headers=headers)
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError as e:
-                raise Exception(e)
-
-            response_body = json.loads(response.text)
-            data = data + response_body
-        final_data += data
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(f"Error fetching data from JumpCloud: {e}")
+        raise Exception(e)
+        
+    if response.text.strip() == "[]":
+        print(f"No results returned for {service} in this time slice. Exiting cleanly.")
+        return
+        
+    data = json.loads(response.text)
+    print(f"Fetched initial batch of {len(data)} records.")
+    
+    # Paginate
+    while int(response.headers.get("X-Result-Count", 0)) >= int(response.headers.get("X-Limit", 10000)):
+        print("Pagination limit reached. Fetching next batch...")
+        body["search_after"] = json.loads(response.headers["X-Search_After"])
+        response = requests.post(url, json=body, headers=headers)
+        response.raise_for_status()
+        new_data = json.loads(response.text)
+        data += new_data
+        print(f"Fetched additional {len(new_data)} records.")
+        
+    final_data += data
 
     if len(final_data) == 0:
         return
-    else:
-        outfile_name = "jc_directoryinsights_" + start_date + "_" + end_date + ".json"
+        
+    final_data.sort(key=lambda x: x['timestamp'], reverse=True)
+    out_file_name = f"jc_directoryinsights_{service}_{start_date}_{end_date}.json.gz"
+    out_file_name = out_file_name.replace(":", "-") # Safe characters for Storage
+    tmp_file_path = f"/tmp/{out_file_name}"
+    
+    # Compress the file
+    print(f"Formatting as {json_format} and compressing {len(final_data)} records to GZIP...")
+    try:
+        with gzip.GzipFile(filename=tmp_file_path, mode="w", compresslevel=9) as gz_out_file:
+            if json_format == "NDJson":
+                # Apply BigQuery sanitization and write line-by-line
+                for item in final_data:
+                    cleaned_item = sanitize_payload(item)
+                    gz_out_file.write((json.dumps(cleaned_item) + '\n').encode('UTF-8'))
+            elif json_format == "SingleLine":
+                gz_out_file.write(('[' + ',\n'.join(json.dumps(i) for i in final_data) + ']').encode('UTF-8'))
+            else:
+                gz_out_file.write(json.dumps(final_data, indent=2).encode("UTF-8"))
+    except Exception as e:
+        print(f"Error compressing file: {e}")
+        raise Exception(e)
+
+    # Upload to Cloud Storage
+    print(f"Uploading {out_file_name} to Cloud Storage bucket: {bucket_name}...")
+    try:
         client = storage.Client()
-        bucket = client.get_bucket(bucket_name)
-        blob = bucket.blob(outfile_name)
-        blob.upload_from_string(
-            data=json.dumps(final_data),
-            content_type='application/json'
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(out_file_name)
+        
+        # Explicit content_type forces browsers to download instead of displaying raw binary text
+        blob.upload_from_filename(tmp_file_path, content_type='application/gzip')
+        
+        print(f"SUCCESS! File uploaded to GCS.")
+    except Exception as e:
+        print(f"Error uploading to GCS: {e}")
+        raise Exception(e)
+        
+    print("--- WORKER COMPLETE ---")
+    
+    # (Keep all your existing imports and code above this line)
+
+# ==============================================================================
+# REDRIVE FUNCTION (Triggered by HTTP)
+# ==============================================================================
+def redrive_dlq(request):
+    """HTTP Cloud Function to redrive messages from a DLQ to a Main Topic."""
+    print("--- REDRIVE INITIATED ---")
+    
+    try:
+        project_id = os.environ.get('gcp_project_id')
+        dlq_sub_id = os.environ.get('dlq_sub_id')
+        main_topic_id = os.environ.get('main_topic_id')
+
+        if not all([project_id, dlq_sub_id, main_topic_id]):
+            return ("Missing required environment variables.", 500)
+
+        subscriber = pubsub_v1.SubscriberClient()
+        publisher = pubsub_v1.PublisherClient()
+
+        subscription_path = subscriber.subscription_path(project_id, dlq_sub_id)
+        topic_path = publisher.topic_path(project_id, main_topic_id)
+
+        print(f"Pulling messages from {dlq_sub_id}...")
+        
+        # Pull up to 100 messages at a time
+        response = subscriber.pull(
+            request={"subscription": subscription_path, "max_messages": 100}
         )
 
-# Http function for GC Functions
-def run_di(httpRequest):
-    requests_args = httpRequest.args
+        if not response.received_messages:
+            print("DLQ is empty! Nothing to move.")
+            return ("DLQ is empty. No messages moved.", 200)
 
-    if requests_args and "message" in requests_args:
-        message = requests_args["message"]
-    else:
-        jc_directory_insights()
-        message = 'DI successfully ran'
-    return message
+        ack_ids = []
+        moved_count = 0
+
+        for received_message in response.received_messages:
+            try:
+                # 1. Forward the raw data back to the main topic
+                publisher.publish(topic_path, received_message.message.data)
+                
+                # 2. Save the ID so we can delete it from the DLQ
+                ack_ids.append(received_message.ack_id)
+                moved_count += 1
+            except Exception as e:
+                print(f"Failed to publish message {received_message.message.message_id}: {e}")
+                # We do NOT add to ack_ids so it stays in the DLQ to try again later
+
+        # 3. Tell the DLQ we successfully moved them, so it can delete them safely
+        if ack_ids:
+            subscriber.acknowledge(
+                request={"subscription": subscription_path, "ack_ids": ack_ids}
+            )
+            
+        result_message = f"🏁 Successfully redelivered {moved_count} messages to {main_topic_id}!"
+        print(result_message)
+        
+        return (result_message, 200)
+
+    except Exception as e:
+        print(f"Error during redrive: {e}")
+        return (f"Failed to pull messages: {e}", 500)

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -352,20 +352,35 @@ def redrive_dlq(request):
             print("DLQ is empty! Nothing to move.")
             return ("DLQ is empty. No messages moved.", 200)
 
+        # 1. Create a list to track the publish operations and their associated ack_ids
+        publish_tasks = []
+
+        for received_message in response.received_messages:
+            # Fire off the publish command and capture the Future
+            future = publisher.publish(topic_path, received_message.message.data)
+            
+            # Store the Future alongside the ack_id and message_id so we can evaluate them together later
+            publish_tasks.append({
+                "future": future,
+                "ack_id": received_message.ack_id,
+                "msg_id": received_message.message.message_id
+            })
+
         ack_ids = []
         moved_count = 0
 
-        for received_message in response.received_messages:
+        # 2. Wait for each publish to finish
+        for task in publish_tasks:
             try:
-                # 1. Forward the raw data back to the main topic
-                publisher.publish(topic_path, received_message.message.data)
+                # This forces the code to wait for confirmation that the main topic received it
+                task["future"].result()
                 
-                # 2. Save the ID so we can delete it from the DLQ
-                ack_ids.append(received_message.ack_id)
+                # If we get here, it succeeded! It is now safe to queue it for deletion from the DLQ
+                ack_ids.append(task["ack_id"])
                 moved_count += 1
             except Exception as e:
-                print(f"Failed to publish message {received_message.message.message_id}: {e}")
-                # We do NOT add to ack_ids so it stays in the DLQ to try again later
+                print(f"Failed to publish message {task['msg_id']}: {e}")
+                # We intentionally do NOT add it to ack_ids, so it safely remains in the DLQ
 
         # 3. Tell the DLQ we successfully moved them, so it can delete them safely
         if ack_ids:

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -52,7 +52,7 @@ def get_secret(project_id, secret_name):
         response = client.access_secret_version(request={"name": name})
         return response.payload.data.decode("UTF-8")
     except Exception as e:
-        print(f"Error retrieving secret {secret_name}: {e}")
+        print(f"Error retrieving secret: {e}")
         raise Exception(e)
 
 def get_cron_time(cron_expression, time_tolerance):
@@ -109,7 +109,7 @@ def jc_orchestrator(request):
         fetched_id = get_secret(project_id, jc_org_id_secret_name).strip()
         if fetched_id:
             jc_org_id = fetched_id
-            print(f"Org ID loaded: {jc_org_id}")
+            print(f"Org ID loaded")
 
     time_tolerance = 10
     now, previous_time = get_cron_time(cron_schedule, time_tolerance)

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -74,6 +74,56 @@ def chunk_time_range(start_time, end_time, chunks):
     delta = (end_time - start_time) / chunks
     return [(start_time + delta * i, start_time + delta * (i + 1)) for i in range(chunks)]
 
+def parse_utc_datetime(value):
+    """
+    Parse start_time / end_time from HTTP JSON.
+
+    Dynamic (evaluated at request time, UTC):
+      - "now" — current instant
+      - "now-30" or "now-30d" — 30 days before now (suffix: d=days, h=hours, m=minutes, s=seconds; bare number = days)
+
+    Fixed: ISO-8601, or YYYY-MM-DD:HH:MM:SS (colon between date and time). Naive values are UTC.
+    """
+    if value is None:
+        raise ValueError("Timestamp is missing")
+    s_raw = str(value).strip()
+    if not s_raw:
+        raise ValueError("Timestamp is empty")
+
+    s_key = s_raw.lower()
+    utc = datetime.timezone.utc
+    now = datetime.datetime.now(utc)
+
+    if s_key == "now":
+        return now
+
+    rel = re.match(r"^now-(\d+)([dhms])?$", s_key)
+    if rel:
+        n = int(rel.group(1))
+        unit = rel.group(2) or "d"
+        if unit == "d":
+            delta = datetime.timedelta(days=n)
+        elif unit == "h":
+            delta = datetime.timedelta(hours=n)
+        elif unit == "m":
+            delta = datetime.timedelta(minutes=n)
+        else:
+            delta = datetime.timedelta(seconds=n)
+        return now - delta
+
+    s = s_raw
+    # Allow 2026-03-31:00:00:00 — normalize third colon (date/time boundary) to 'T'
+    if len(s) > 10 and s[10] == ":":
+        s = s[:10] + "T" + s[11:]
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    dt = datetime.datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=utc)
+    else:
+        dt = dt.astimezone(utc)
+    return dt
+
 # ==============================================================================
 # ORCHESTRATOR FUNCTION (Triggered by HTTP via Cloud Scheduler)
 # ==============================================================================
@@ -91,13 +141,14 @@ def jc_orchestrator(request):
         print(f"Missing env var: {e}")
         return f"Missing env var: {e}", 500
 
-    # --- Check for manual test payload from GCP Console ---
+    # --- Optional JSON: explicit window (start_time + end_time) or service override ---
     request_json = request.get_json(silent=True) or {}
-    test_event_days = request_json.get('event_days')
-    test_service = request_json.get('service')
+    raw_start = request_json.get("start_time")
+    raw_end = request_json.get("end_time")
+    test_service = request_json.get("service")
 
     if test_service:
-        print(f"[TEST MODE] Overriding default service with: {test_service}")
+        print(f"[MANUAL] Overriding default service with: {test_service}")
         service_env = test_service
 
     print("Fetching API Key from Secret Manager...")
@@ -111,25 +162,33 @@ def jc_orchestrator(request):
             jc_org_id = fetched_id
             print(f"Org ID loaded")
 
-    # --- Determine Time Window (Test Payload vs Cron Schedule) ---
-    if test_event_days:
-        # Test Mode: Use the provided days back
-        print(f"[TEST MODE] 'event_days' payload detected. Calculating window for the past {test_event_days} days.")
+    # --- Time window: explicit [start_time, end_time] OR cron schedule ---
+    has_start = raw_start is not None and str(raw_start).strip() != ""
+    has_end = raw_end is not None and str(raw_end).strip() != ""
+
+    if has_start ^ has_end:
+        error_msg = "Provide both start_time and end_time for a manual window, or omit both for scheduled (cron) mode."
+        print(error_msg)
+        return error_msg, 400
+
+    if has_start and has_end:
         try:
-            days_back = int(test_event_days)
-            now = datetime.datetime.now(datetime.timezone.utc)
-            previous_time = now - datetime.timedelta(days=days_back)
-        except ValueError:
-            error_msg = "Invalid 'event_days' value. Must be a whole number (integer)."
+            window_start = parse_utc_datetime(raw_start)
+            window_end = parse_utc_datetime(raw_end)
+        except ValueError as e:
+            error_msg = f"Invalid start_time or end_time: {e}"
             print(error_msg)
             return error_msg, 400
-            
+        if window_start >= window_end:
+            error_msg = "start_time must be strictly before end_time."
+            print(error_msg)
+            return error_msg, 400
+        print(f"[MANUAL WINDOW] {window_start.isoformat()} to {window_end.isoformat()}")
     else:
-        # Production Mode: Normal Cron Run
         time_tolerance = 10
-        now, previous_time = get_cron_time(cron_schedule, time_tolerance)
-        
-    print(f"Search Window: {previous_time} to {now}")
+        window_end, window_start = get_cron_time(cron_schedule, time_tolerance)
+
+    print(f"Search Window: {window_start} to {window_end}")
     
     publisher = pubsub_v1.PublisherClient()
     topic_path = publisher.topic_path(project_id, topic_name)
@@ -160,8 +219,8 @@ def jc_orchestrator(request):
             print(f"Unknown service: {service}")
             continue
 
-        start_iso = previous_time.isoformat("T").replace("+00:00", "Z")
-        end_iso = now.isoformat("T").replace("+00:00", "Z")
+        start_iso = window_start.isoformat("T").replace("+00:00", "Z")
+        end_iso = window_end.isoformat("T").replace("+00:00", "Z")
         
         count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
         
@@ -183,7 +242,7 @@ def jc_orchestrator(request):
             continue 
 
         num_chunks = max(1, math.ceil(total_events / MAX_EVENTS_PER_WORKER))
-        time_slices = chunk_time_range(previous_time, now, num_chunks)
+        time_slices = chunk_time_range(window_start, window_end, num_chunks)
         print(f"Splitting {service} into {num_chunks} chunk(s) for the workers.")
         
         for slice_start, slice_end in time_slices:

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -149,7 +149,6 @@ def jc_orchestrator(request):
         
         count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
         
-        # Omit the service parameter if querying 'all' to prevent 400 Bad Request
         count_body = {'service': [service], 'start_time': start_iso, 'end_time': end_iso}
         
         print(f"[ORCHESTRATOR] Querying Count URL: {count_url} | Service: {service}")

--- a/GCP/DirectoryInsights/requirements.txt
+++ b/GCP/DirectoryInsights/requirements.txt
@@ -1,5 +1,6 @@
-python-dateutil~=2.8.2
-requests~=2.32.0
-google-cloud-storage~=2.2.1
-croniter~=1.3.4
-
+requests==2.31.0
+croniter==2.0.1
+google-cloud-secret-manager==2.16.2
+google-cloud-pubsub==2.18.4
+google-cloud-storage==2.13.0
+functions-framework==3.4.0


### PR DESCRIPTION
## Issues
* [CUT-5094](https://jumpcloud.atlassian.net/browse/CUT-5094) - CUT-5094-GCP-3.0

## What does this solve?
This PR introduces a major architectural overhaul to the JumpCloud Directory Insights GCP integration, migrating it to a highly resilient, event-driven Orchestrator-Worker pattern using Google Cloud Pub/Sub. Similar functionality with the AWS Serverless App

## Is there anything particularly tricky?
* Since GCP does not have a ReDrive functionality built in the Pub/Sub DLQ topic. I have created a Cloud Function to run manually if there are messages in the DLQ.
* GCP requires granular permissions. Ensure that the README doc permission instructions are all good and you are encountering any build issues due missing permissions. If so, let me know so we can add it in the doc.
 
## How should this be tested?

1.  **Standard Deployment:** Run `gcloud builds submit` from the root directory and ensure all resources (Topics, Subscriptions, Functions, Scheduler) spin up without permission errors.
    
2.  **Automated Run:** Wait for the 5-minute cron schedule to hit. Check the GCS Bucket to verify a new `.json.gz` file is successfully formatted and uploaded.
    
3.  **Manual Force Run (Backfill):** Go to Cloud Scheduler and click **Force Run**. Check the Orchestrator logs to verify it prints `"Manual Force Run detected!"` and successfully chunks the historical lookback window (e.g., 30 or 90 days) into the queue.
    
4.  **DLQ & Redrive Test:**
    
    -   Intentionally break the worker (e.g., change the JumpCloud API key to an invalid string in Secret Manager).
        
    -   Trigger a run.
        
    -   Verify the message fails 5 times and lands in the `jc-di-jobs-dlq-sub` subscription.
        
    -   Fix the API key.
        
    -   Go to the `jc-di-redrive` Cloud Function and click **Test Function**.
        
    -   Verify the function returns `Successfully redelivered X messages` and the Worker successfully processes the redriven message.

5. Go through doc changes on the README.md file
## Screenshots
## DLQ
<img width="2245" height="665" alt="image" src="https://github.com/user-attachments/assets/ec14a0a0-0537-418a-bb1a-38d9533e47d2" />
<img width="790" height="693" alt="image" src="https://github.com/user-attachments/assets/6bc17656-150b-47d4-8120-3ca1028da829" />
<img width="2270" height="883" alt="image" src="https://github.com/user-attachments/assets/58a308e0-904a-428e-9776-6493e841960f" />
<img width="745" height="93" alt="image" src="https://github.com/user-attachments/assets/1c389dbe-21fe-4158-a474-7c71991300b6" />


[CUT-5094]: https://jumpcloud.atlassian.net/browse/CUT-5094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it replaces the core execution/deployment model (single HTTP function) with multiple functions, Pub/Sub/DLQ wiring, new IAM requirements, and new output formatting/compression that can affect data completeness and operational reliability.
> 
> **Overview**
> Migrates Directory Insights collection from a single HTTP Cloud Function into a **3-function Orchestrator/Worker/Redrive** pipeline: the `jc_orchestrator` HTTP function calculates a time window (cron or explicit `start_time`/`end_time`), queries JumpCloud event counts, and enqueues chunked jobs to Pub/Sub; the `jc_worker` consumes jobs, paginates events, and uploads **compressed `.json.gz`** files to GCS with selectable formats (`MultiLine`, `SingleLine`, `NDJson`) and optional **BigQuery key sanitization** for NDJson.
> 
> Updates `cloudbuild.yaml` to deploy Python 3.12 functions, create the GCS bucket and secrets, provision Pub/Sub main/DLQ topics, attach a DLQ policy to the worker subscription, and deploy an HTTP `redrive_dlq` function that republishes messages from a DLQ pull subscription back to the main topic. Documentation and ignore rules are expanded to cover the new architecture, manual backfill/testing inputs, required `pubsub` enablement/roles, and updated dependency/runtime versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d070597efd7c2764f7c4c15e8c7bbf6122e47f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->