### PR TITLE
Service Account & Multi-ORG support for Enterprise Clients

### DIFF
--- a/GCP/DirectoryInsights/CHANGELOG.md
+++ b/GCP/DirectoryInsights/CHANGELOG.md
@@ -1,19 +1,29 @@
 # Changelog
 
+## [3.1.0] - 2026-04-08
+
+### Added
+
+- Provides support for clientID, clientSecret authorization.
+- Provides support for multiple ORGs to be queried and configured at the same time. Bucket items for multiple orgs will be stored in the same bucket.
+
 ## [3.0.0] - 2026-04-08
 
 ### Added
--  Introduces a major architectural overhaul to the JumpCloud Directory Insights GCP integration, migrating it to a highly resilient, event-driven Orchestrator-Worker pattern using Google Cloud Pub/Sub. Similar functionality with the AWS Serverless App
+
+- Introduces a major architectural overhaul to the JumpCloud Directory Insights GCP integration, migrating it to a highly resilient, event-driven Orchestrator-Worker pattern using Google Cloud Pub/Sub. Similar functionality with the AWS Serverless App
 
 ## [1.0.3] - 2025-03-03
 
 ### Fixes
+
 - Scheduling data gaps
 - Fixed issues with deploying cloud run functions
 
 ## [1.0.2] - 2023-09-25
 
 ### Fixes
+
 - Updated Requests package version to 2.31.0 in the requirements file
 
 ## [1.0.1] - 2022-06-13
@@ -25,7 +35,7 @@
 
 ### Fixes
 
-- Added string quotations and note for _GCP_PROJECT_ID parameter in Cloudbuild.yaml to fix incorrect type error
+- Added string quotations and note for \_GCP_PROJECT_ID parameter in Cloudbuild.yaml to fix incorrect type error
 
 ## [1.0.0] - 2022-03-31
 

--- a/GCP/DirectoryInsights/CHANGELOG.md
+++ b/GCP/DirectoryInsights/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.0] - 2026-04-08
+
+### Added
+-  Introduces a major architectural overhaul to the JumpCloud Directory Insights GCP integration, migrating it to a highly resilient, event-driven Orchestrator-Worker pattern using Google Cloud Pub/Sub. Similar functionality with the AWS Serverless App
+
 ## [1.0.3] - 2025-03-03
 
 ### Fixes

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -18,7 +18,10 @@ _Note: This document assumes the use of Python 3.12 on GCP Cloud Functions_
   - [Key Features](#key-features)
 - [Pre-requisites](#pre-requisites)
 - [Create Directory to Store Directory Insights Files](#create-directory-to-store-directory-insights-files)
-- [Edit CloudBuild.yaml](#edit-cloudbuildyaml)
+- [Edit `cloudbuild.yaml`](#edit-cloudbuildyaml)
+- [Cloud Build substitutions](#cloud-build-substitutions)
+- [Authentication: API key and service account (OAuth)](#authentication-api-key-and-service-account-oauth)
+- [Multiple organizations](#multiple-organizations)
 - [Deploying the Application](#deploying-the-application)
 - [Manual Testing \& Historical Backfill](#manual-testing--historical-backfill)
   - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console)
@@ -61,17 +64,21 @@ The `gcloud builds submit` command orchestrates the creation of the following in
 
 ### 5. Secret Manager
 
-- **API Credentials:** Secure storage for your `JumpCloud API Key` and `Organization ID`, ensuring no sensitive credentials are hardcoded in the functions or environment variables.
+- **API credentials:** One secret holds the JumpCloud credential (API key **or** OAuth client ID and secret, depending on auth mode). A second secret holds the **organization ID** (single value, or a comma-separated list when multi-org mode is enabled). Values are created or **updated** on each successful build (a new secret version is added; functions use `latest`).
 
 ## Key Features
 
 - **Auto-Scaling:** If JumpCloud has 100,000 events in a 5-minute window, the Orchestrator will automatically split that into multiple Pub/Sub messages, allowing multiple Worker instances to process the data simultaneously.
+- **Authentication options:** Use a standard JumpCloud **API key** or **OAuth client credentials** (client ID and secret) to obtain bearer tokens for the Insights API. See [documentation on service Accounts](https://jumpcloud.com/support/service-account-for-apis)
+- **Multiple organizations:** Optional multi-org mode runs counts and exports per organization and writes distinct objects per org in Cloud Storage.
 - **BigQuery Ready:** When using the `NDJson` format, the application automatically sanitizes JSON keys (replacing spaces/hyphens with underscores) to ensure the files can be ingested into BigQuery without schema errors.
 - **Manual Recovery:** The "Force Run" logic allows you to trigger a large historical backfill (up to 90 days) simply by clicking "Force Run" in the Cloud Scheduler console.
 
 # Pre-requisites
 
-- [Your JumpCloud API key](https://docs.jumpcloud.com/2.0/authentication-and-authorization/authentication-and-authorization-overview)
+- JumpCloud credentials in one of these forms (see [Authentication](#authentication-api-key-and-service-account-oauth)):
+  - A [JumpCloud API key](https://docs.jumpcloud.com/2.0/authentication-and-authorization/authentication-and-authorization-overview) (`jca_...`), **or**
+  - An OAuth **client ID** and **client secret** pair from your JumpCloud admin OAuth / API integration, if you deploy with **ServiceToken** auth (organization ID is required for that mode).
 - Google Cloud Admin/Owner account with these roles:
   - `roles/serviceusage.serviceUsageAdmin`
   - `roles/cloudbuild.builds.editor`
@@ -134,9 +141,59 @@ gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJE
 
 Create a directory to store your Serverless Application and any dependencies required. In the root of that directory add [Directory Insights Files](https://github.com/TheJumpCloud/JumpCloud-Serverless/blob/master/GCP/DirectoryInsights/).
 
-# Edit CloudBuild.yaml
+# Edit `cloudbuild.yaml`
 
-In the root directory, edit cloudbuid.yaml file `substitutions` variable values `CHANGEVALUE` with the necessary credentials
+In the project directory, edit `cloudbuild.yaml` and set the `substitutions` values (replace `CHANGEVALUE` placeholders where applicable). See [Cloud Build substitutions](#cloud-build-substitutions) for every option.
+
+# Cloud Build substitutions
+
+| Substitution                         | Purpose                                                                                                                                                                                         |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_JC_AUTH_TYPE`                      | `APIKey` (default) or `ServiceToken`. Controls how the Orchestrator and Worker authenticate to JumpCloud Insights.                                                                              |
+| `_JC_API_KEY`                        | Stored in Secret Manager as `{_RESOURCE_PREFIX}-api-key`. **APIKey:** your JumpCloud API key. **ServiceToken:** a single string `clientID:clientSecret` (used to obtain an OAuth access token). |
+| `_JC_ORG_ID`                         | Stored as `{_RESOURCE_PREFIX}-org-id`. **Single-org:** one organization ID. **Multi-org:** when `_JC_MULTI_ORG` is `true`, a comma-separated list, e.g. `orgId1,orgId2`.                        |
+| `_JC_MULTI_ORG`                      | `false` (default) or `true`. When `true`, `_JC_ORG_ID` is split on commas and each org is processed separately (separate count queries, Pub/Sub jobs, and output files).                        |
+| `_JC_SERVICE`                        | Insights services to collect (e.g. `all`, `directory`, or a comma-separated list).                                                                                                              |
+| `_RESOURCE_PREFIX`                   | Prefix for bucket name, secrets, function names, Pub/Sub topics, and scheduler job.                                                                                                             |
+| `_SCHEDULE_CRON_TIME`                | Cron schedule for the Orchestrator (UTC).                                                                                                                                                       |
+| `_GCP_PROJECT_ID_NAME`               | GCP project ID.                                                                                                                                                                                 |
+| `_JSON_FORMAT`                       | `MultiLine`, `SingleLine`, or `NDJson`.                                                                                                                                                         |
+| `_STORAGE_CLASS`, `_REGION_LOCATION` | Bucket storage class and region.                                                                                                                                                                |
+| `_MAX_EVENTS_PER_WORKER`             | Chunk size used by the Orchestrator when splitting work.                                                                                                                                        |
+| `_WORKER_MEMORY`                     | Memory for the Worker Cloud Function.                                                                                                                                                           |
+
+On each build, the pipeline **creates** the API key and org secrets if they do not exist, or **adds a new version** if they already exist, so you can rotate credentials by updating substitutions and re-running `gcloud builds submit`.
+
+# Authentication: API key and service account (OAuth)
+
+The Orchestrator calls the Insights **event count** API per time window; Workers call the **events** API with pagination. Both use the same auth mode.
+
+### API key (`_JC_AUTH_TYPE`: `APIKey`)
+
+- The `{_RESOURCE_PREFIX}-api-key` secret must contain your JumpCloud API key.
+- Requests use the `x-api-key` header. If an organization ID is configured, `x-org-id` is sent as well (optional for some tenants; required for multi-org and for Insights when scoped by org).
+
+### Service account / OAuth client credentials (`_JC_AUTH_TYPE`: `ServiceToken`)
+
+- The **same** secret name `{_RESOURCE_PREFIX}-api-key` must contain **`clientID:clientSecret`** (one colon between ID and secret).
+- At runtime the functions call JumpCloud’s token endpoint (`https://admin-oauth.id.jumpcloud.com/oauth2/token`) with HTTP Basic auth (Base64 of `clientID:clientSecret`), `grant_type=client_credentials`, and `scope=api`, then call Insights with **`Authorization: Bearer <access_token>`** and **`x-org-id`**.
+- **An organization ID is required** for ServiceToken (configure the org secret; for multi-org, use the comma-separated list with `_JC_MULTI_ORG=true`).
+
+# Multiple organizations
+
+Enterprise customers may use one API key or one OAuth client to access **several** JumpCloud organizations.
+
+1. Set **`_JC_MULTI_ORG`** to **`true`** in `cloudbuild.yaml` (or pass `--substitutions=_JC_MULTI_ORG=true` when submitting the build).
+2. Set **`_JC_ORG_ID`** to a **comma-separated** list of organization IDs (optional spaces after commas are trimmed).
+3. Redeploy so the Orchestrator and Worker receive `jc_multi_org=true`.
+
+**Behavior**
+
+- The Orchestrator loops each org: it builds request headers for that org, calls **`/insights/directory/v1/events/count`** per org and service, splits time ranges when needed, and enqueues one Pub/Sub message per chunk. Each message includes an **`org_id`** field so the Worker knows which tenant to query.
+- The Worker reads **`org_id`** from the message (required when `jc_multi_org` is true). Older messages without `org_id` still work when `jc_multi_org` is false by falling back to the org secret.
+- Uploaded files are named so different orgs do not overwrite each other:  
+  `jc_directoryinsights_<orgId>_<service>_<start>_<end>.json.gz`  
+  When no org ID is used (legacy single-tenant flow without `x-org-id`), the file name matches the previous pattern without the org prefix.
 
 # Deploying the Application
 

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,8 +1,9 @@
 substitutions:
-  # Authentication: APIKey (JumpCloud API key in the api-key secret) or ServiceToken (OAuth client credentials in the form clientID:clientSecret in the same secret).
-  _JC_AUTH_TYPE: "ServiceToken"
+  # Authentication: 'APIKey' (JumpCloud API key in the api-key secret) or 'ServiceToken' (OAuth client credentials in the form clientID:clientSecret in the same secret).
+  _JC_AUTH_TYPE: "APIKey"
   _JC_API_KEY: "CHANGEVALUE"
   _JC_ORG_ID: "CHANGEVALUE"
+  # true = treat _JC_ORG_ID / org secret as comma-separated org list (e.g. "org1,org2"); false = one org id (entire string) (default).
   _JC_MULTI_ORG: "false"
   _JC_SERVICE: "CHANGEVALUE" # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services:
   ### all, access_management, alerts, asset_management, directory, ldap, mdm, notifications, object_storage, password_manager, radius, reports, saas_app_management, software, sso, systems, workflows. ###

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -27,6 +27,10 @@ steps:
           echo "Invalid _JC_AUTH_TYPE: must be APIKey or ServiceToken"
           exit 1
         fi
+        if [[ "$_JC_MULTI_ORG" != "true" && "$_JC_MULTI_ORG" != "false" ]]; then
+          echo "Invalid _JC_MULTI_ORG: must be true or false"
+          exit 1
+        fi
 
   # Storage bucket creation
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
@@ -83,7 +87,7 @@ steps:
       - --region=$_REGION_LOCATION
       - --source=.
       - --runtime=python312
-      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,max_events_per_worker=$_MAX_EVENTS_PER_WORKER,jc_auth_type=$_JC_AUTH_TYPE
+      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,max_events_per_worker=$_MAX_EVENTS_PER_WORKER,jc_auth_type=$_JC_AUTH_TYPE,jc_multi_org=$_JC_MULTI_ORG
       - --entry-point=jc_orchestrator
       - --trigger-http
       - --no-allow-unauthenticated
@@ -100,7 +104,7 @@ steps:
           --region=$_REGION_LOCATION \
           --source=. \
           --runtime=python312 \
-          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,bucket_name=${_RESOURCE_PREFIX}-di-bucket,json_format=$_JSON_FORMAT,jc_auth_type=$_JC_AUTH_TYPE \
+          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,bucket_name=${_RESOURCE_PREFIX}-di-bucket,json_format=$_JSON_FORMAT,jc_auth_type=$_JC_AUTH_TYPE,jc_multi_org=$_JC_MULTI_ORG \
           --entry-point=jc_worker \
           --memory=$_WORKER_MEMORY \
           --trigger-topic=${_RESOURCE_PREFIX}-jobs \

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,9 +1,7 @@
 substitutions:
   # Authentication: APIKey (JumpCloud API key in the api-key secret) or ServiceToken (OAuth client credentials in the form clientID:clientSecret in the same secret).
   _JC_AUTH_TYPE: "ServiceToken"
-  _JC_API_KEY: "CHANGEVALUE"
-  _JC_ORG_ID: "CHANGEVALUE"
-  _JC_SERVICE: "CHANGEVALUE" # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services:
+  _JC_MULTI_ORG: "false"
   ### all, access_management, alerts, asset_management, directory, ldap, mdm, notifications, object_storage, password_manager, radius, reports, saas_app_management, software, sso, systems, workflows. ###
   # Prefix for GCS bucket, secrets, functions, Pub/Sub, and scheduler.
   _RESOURCE_PREFIX: "jc-di"

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,4 +1,6 @@
 substitutions:
+  # Authentication: APIKey (JumpCloud API key in the api-key secret) or ServiceToken (OAuth client credentials in the form clientID:clientSecret in the same secret).
+  _JC_AUTH_TYPE: "ServiceToken"
   _JC_API_KEY: "CHANGEVALUE"
   _JC_ORG_ID: "CHANGEVALUE"
   _JC_SERVICE: "CHANGEVALUE" # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services:
@@ -20,6 +22,11 @@ steps:
       - -c
       - |
         if [[ "$_JSON_FORMAT" != "MultiLine" && "$_JSON_FORMAT" != "SingleLine" && "$_JSON_FORMAT" != "NDJson" ]]; then
+          echo "Invalid _JSON_FORMAT: must be MultiLine, SingleLine, or NDJson"
+          exit 1
+        fi
+        if [[ "$_JC_AUTH_TYPE" != "APIKey" && "$_JC_AUTH_TYPE" != "ServiceToken" ]]; then
+          echo "Invalid _JC_AUTH_TYPE: must be APIKey or ServiceToken"
           exit 1
         fi
 
@@ -32,14 +39,29 @@ steps:
         gsutil ls -p $_GCP_PROJECT_ID_NAME gs://${_RESOURCE_PREFIX}-di-bucket >/dev/null 2>&1 || \
         gsutil mb -p $_GCP_PROJECT_ID_NAME -c $_STORAGE_CLASS -l $_REGION_LOCATION gs://${_RESOURCE_PREFIX}-di-bucket
 
-  # Create Secrets
+  # Create or update Secrets (new version becomes "latest" for functions using versions/latest)
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: bash
     args:
       - -c
       - |
-        echo -n "$_JC_API_KEY" | gcloud secrets create ${_RESOURCE_PREFIX}-api-key --data-file=- || true
-        echo -n "$_JC_ORG_ID" | gcloud secrets create ${_RESOURCE_PREFIX}-org-id --data-file=- || true
+        PROJECT_ID="$_GCP_PROJECT_ID_NAME"
+        API_SECRET="${_RESOURCE_PREFIX}-api-key"
+        ORG_SECRET="${_RESOURCE_PREFIX}-org-id"
+        if gcloud secrets describe "$$API_SECRET" --project="$$PROJECT_ID" >/dev/null 2>&1; then
+          echo "Updating secret version: $$API_SECRET"
+          echo -n "$_JC_API_KEY" | gcloud secrets versions add "$$API_SECRET" --project="$$PROJECT_ID" --data-file=-
+        else
+          echo "Creating secret: $$API_SECRET"
+          echo -n "$_JC_API_KEY" | gcloud secrets create "$$API_SECRET" --project="$$PROJECT_ID" --data-file=-
+        fi
+        if gcloud secrets describe "$$ORG_SECRET" --project="$$PROJECT_ID" >/dev/null 2>&1; then
+          echo "Updating secret version: $$ORG_SECRET"
+          echo -n "$_JC_ORG_ID" | gcloud secrets versions add "$$ORG_SECRET" --project="$$PROJECT_ID" --data-file=-
+        else
+          echo "Creating secret: $$ORG_SECRET"
+          echo -n "$_JC_ORG_ID" | gcloud secrets create "$$ORG_SECRET" --project="$$PROJECT_ID" --data-file=-
+        fi
 
   # Create Pub/Sub Topics (Main queue and DLQ)
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
@@ -63,7 +85,7 @@ steps:
       - --region=$_REGION_LOCATION
       - --source=.
       - --runtime=python312
-      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,max_events_per_worker=$_MAX_EVENTS_PER_WORKER
+      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,max_events_per_worker=$_MAX_EVENTS_PER_WORKER,jc_auth_type=$_JC_AUTH_TYPE
       - --entry-point=jc_orchestrator
       - --trigger-http
       - --no-allow-unauthenticated
@@ -80,7 +102,7 @@ steps:
           --region=$_REGION_LOCATION \
           --source=. \
           --runtime=python312 \
-          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,bucket_name=${_RESOURCE_PREFIX}-di-bucket,json_format=$_JSON_FORMAT \
+          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,bucket_name=${_RESOURCE_PREFIX}-di-bucket,json_format=$_JSON_FORMAT,jc_auth_type=$_JC_AUTH_TYPE \
           --entry-point=jc_worker \
           --memory=$_WORKER_MEMORY \
           --trigger-topic=${_RESOURCE_PREFIX}-jobs \

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,6 +1,7 @@
 substitutions:
   # Authentication: 'APIKey' (JumpCloud API key in the api-key secret) or 'ServiceToken' (OAuth client credentials in the form clientID:clientSecret in the same secret).
   _JC_AUTH_TYPE: "APIKey"
+  # API Key: API key (x-api-key) for APIKey auth type. For ServiceToken auth type, this is the clientID:clientSecret in the same secret.
   _JC_API_KEY: "CHANGEVALUE"
   _JC_ORG_ID: "CHANGEVALUE"
   # true = treat _JC_ORG_ID / org secret as comma-separated org list (e.g. "org1,org2"); false = one org id (entire string) (default).

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -1,7 +1,10 @@
 substitutions:
   # Authentication: APIKey (JumpCloud API key in the api-key secret) or ServiceToken (OAuth client credentials in the form clientID:clientSecret in the same secret).
   _JC_AUTH_TYPE: "ServiceToken"
+  _JC_API_KEY: "CHANGEVALUE"
+  _JC_ORG_ID: "CHANGEVALUE"
   _JC_MULTI_ORG: "false"
+  _JC_SERVICE: "CHANGEVALUE" # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services:
   ### all, access_management, alerts, asset_management, directory, ldap, mdm, notifications, object_storage, password_manager, radius, reports, saas_app_management, software, sso, systems, workflows. ###
   # Prefix for GCS bucket, secrets, functions, Pub/Sub, and scheduler.
   _RESOURCE_PREFIX: "jc-di"

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -59,7 +59,7 @@ def get_secret(project_id, secret_name):
 JC_AUTH_TYPE_API_KEY = "APIKey"
 JC_AUTH_TYPE_SERVICE_TOKEN = "ServiceToken"
 JC_OAUTH_TOKEN_URL = "https://admin-oauth.id.jumpcloud.com/oauth2/token"
-JC_USER_AGENT = "JumpCloud_GCPServerless.DirectoryInsights/3.0.0"
+JC_USER_AGENT = "JumpCloud_GCPServerless.DirectoryInsights/3.1.0"
 
 
 def _normalize_jc_auth_type(value):

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -167,15 +167,16 @@ def build_org_id_list(org_secret_raw, multi_org):
 
 def mask_org_id_for_logs(org_id):
     """
-    Log-safe org ID: first four characters, remainder replaced with asterisks.
+    Log-safe org ID: last four characters visible; all preceding characters replaced with asterisks.
     Does not alter values used for API calls, Pub/Sub payloads, or object names.
     """
     if org_id is None or str(org_id).strip() == "":
         return "(no x-org-id)"
     s = str(org_id).strip()
     n = len(s)
-    show = min(4, n)
-    return s[:show] + "*" * (n - show)
+    if n <= 4:
+        return s
+    return "*" * (n - 4) + s[-4:]
 
 
 def mask_org_id_in_text(text, org_id):

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -123,6 +123,28 @@ def get_jc_request_headers(project_id, api_key_secret_name, jc_org_id, auth_type
     raise ValueError(f"Unknown jc_auth_type: {auth_type!r}; use APIKey or ServiceToken.")
 
 
+def parse_jc_multi_org_flag(value):
+    """True when env jc_multi_org enables comma-separated org list in the org secret."""
+    if value is None:
+        return False
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def build_org_id_list(org_secret_raw, multi_org):
+    """
+    Build the list of org IDs to process.
+
+    multi_org False: one org; empty secret yields [''] (optional x-org-id for API key).
+    multi_org True: split on comma; whitespace trimmed; empty list if no ids.
+    """
+    raw = (org_secret_raw or "").strip()
+    if multi_org:
+        return [p.strip() for p in raw.split(",") if p.strip()]
+    if raw:
+        return [raw]
+    return [""]
+
+
 def get_cron_time(cron_expression, time_tolerance):
     """Calculates the current and previous cron execution times."""
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -205,6 +227,7 @@ def jc_orchestrator(request):
         topic_name = os.environ['pubsub_topic']
         service_env = os.environ['service']
         jc_auth_type = os.environ.get("jc_auth_type", JC_AUTH_TYPE_API_KEY)
+        jc_multi_org = parse_jc_multi_org_flag(os.environ.get("jc_multi_org"))
         print("Environment variables loaded successfully.")
     except KeyError as e:
         print(f"Missing env var: {e}")
@@ -220,25 +243,21 @@ def jc_orchestrator(request):
         print(f"[MANUAL] Overriding default service with: {test_service}")
         service_env = test_service
 
-    jc_org_id = ""
+    org_secret_raw = ""
     if jc_org_id_secret_name:
-        print("Fetching Org ID from Secret Manager...")
-        fetched_id = get_secret(project_id, jc_org_id_secret_name).strip()
-        if fetched_id:
-            jc_org_id = fetched_id
-            print("Org ID loaded")
+        print("Fetching Org ID(s) from Secret Manager...")
+        org_secret_raw = get_secret(project_id, jc_org_id_secret_name).strip()
+        if org_secret_raw:
+            print("Org secret loaded")
 
-    print("Building JumpCloud request headers (credentials from Secret Manager)...")
-    try:
-        headers = get_jc_request_headers(
-            project_id, jc_api_key_secret_name, jc_org_id, jc_auth_type
+    org_ids = build_org_id_list(org_secret_raw, jc_multi_org)
+    if jc_multi_org and not org_ids:
+        error_msg = (
+            "jc_multi_org is true but no organization IDs were found in the org secret "
+            "(use a comma-separated list, e.g. orgId1,orgId2)."
         )
-    except ValueError as e:
-        print(str(e))
-        return str(e), 400
-    except requests.RequestException as e:
-        print(f"JumpCloud OAuth or network error: {e}")
-        return f"Authentication failed: {e}", 502
+        print(error_msg)
+        return error_msg, 400
 
     # --- Time window: explicit [start_time, end_time] OR cron schedule ---
     has_start = raw_start is not None and str(raw_start).strip() != ""
@@ -284,49 +303,67 @@ def jc_orchestrator(request):
     # Create a list to track all of our Pub/Sub publish operations
     publish_futures = []
 
-    for service in service_list:
-        if service not in available_services:
-            print(f"Unknown service: {service}")
-            continue
+    for org_id in org_ids:
+        org_label = org_id if org_id else "(no x-org-id)"
+        print(f"[ORCHESTRATOR] Organization context: {org_label}")
 
-        start_iso = window_start.isoformat("T").replace("+00:00", "Z")
-        end_iso = window_end.isoformat("T").replace("+00:00", "Z")
-        
-        count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
-        
-        count_body = {'service': [service], 'start_time': start_iso, 'end_time': end_iso}
-        
-        print(f"[ORCHESTRATOR] Querying Count URL: {count_url} | Service: {service}")
-        print(f"[ORCHESTRATOR] Payload: {count_body}")
         try:
-            response = requests.post(count_url, json=count_body, headers=headers)
-            response.raise_for_status()
-            total_events = json.loads(response.text).get('count', 0)
-            print(f"Total events found for {service}: {total_events}")
-        except Exception as e:
-            print(f"Failed to get event count for {service}. Defaulting to full slice. Error: {e}")
-            total_events = MAX_EVENTS_PER_WORKER 
-        
-        if total_events == 0:
-            print(f"No events for {service} between {start_iso} and {end_iso}. Skipping.")
-            continue 
+            headers = get_jc_request_headers(
+                project_id, jc_api_key_secret_name, org_id, jc_auth_type
+            )
+        except ValueError as e:
+            print(str(e))
+            return str(e), 400
+        except requests.RequestException as e:
+            print(f"JumpCloud OAuth or network error: {e}")
+            return f"Authentication failed: {e}", 502
 
-        num_chunks = max(1, math.ceil(total_events / MAX_EVENTS_PER_WORKER))
-        time_slices = chunk_time_range(window_start, window_end, num_chunks)
-        print(f"Splitting {service} into {num_chunks} chunk(s) for the workers.")
-        
-        for slice_start, slice_end in time_slices:
-            message_body = {
-                'service': service,
-                'start_time': slice_start.isoformat("T").replace("+00:00", "Z"),
-                'end_time': slice_end.isoformat("T").replace("+00:00", "Z")
-            }
-            
-            # Publish to Pub/Sub and capture the Future object it returns
-            future = publisher.publish(topic_path, json.dumps(message_body).encode("utf-8"))
-            publish_futures.append(future)
-            
-            print(f"Queued job into Pub/Sub: {service} | {message_body['start_time']} to {message_body['end_time']}")
+        for service in service_list:
+            if service not in available_services:
+                print(f"Unknown service: {service}")
+                continue
+
+            start_iso = window_start.isoformat("T").replace("+00:00", "Z")
+            end_iso = window_end.isoformat("T").replace("+00:00", "Z")
+
+            count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
+
+            count_body = {'service': [service], 'start_time': start_iso, 'end_time': end_iso}
+
+            print(f"[ORCHESTRATOR] Querying Count URL: {count_url} | Org: {org_label} | Service: {service}")
+            print(f"[ORCHESTRATOR] Payload: {count_body}")
+            try:
+                response = requests.post(count_url, json=count_body, headers=headers)
+                response.raise_for_status()
+                total_events = json.loads(response.text).get('count', 0)
+                print(f"Total events found for org {org_label} | {service}: {total_events}")
+            except Exception as e:
+                print(f"Failed to get event count for org {org_label} | {service}. Defaulting to full slice. Error: {e}")
+                total_events = MAX_EVENTS_PER_WORKER
+
+            if total_events == 0:
+                print(f"No events for org {org_label} | {service} between {start_iso} and {end_iso}. Skipping.")
+                continue
+
+            num_chunks = max(1, math.ceil(total_events / MAX_EVENTS_PER_WORKER))
+            time_slices = chunk_time_range(window_start, window_end, num_chunks)
+            print(f"Splitting org {org_label} | {service} into {num_chunks} chunk(s) for the workers.")
+
+            for slice_start, slice_end in time_slices:
+                message_body = {
+                    'service': service,
+                    'start_time': slice_start.isoformat("T").replace("+00:00", "Z"),
+                    'end_time': slice_end.isoformat("T").replace("+00:00", "Z"),
+                    'org_id': org_id,
+                }
+
+                future = publisher.publish(topic_path, json.dumps(message_body).encode("utf-8"))
+                publish_futures.append(future)
+
+                print(
+                    f"Queued job into Pub/Sub: org={org_label} | {service} | "
+                    f"{message_body['start_time']} to {message_body['end_time']}"
+                )
 
     # Wait for all messages to be successfully published before exiting the function
     if publish_futures:
@@ -354,15 +391,28 @@ def jc_worker(event, context):
         jc_org_id_secret_name = os.environ.get('jc_org_id', '')
         json_format = os.environ.get('json_format', 'MultiLine') # MultiLine, SingleLine, or NDJson
         jc_auth_type = os.environ.get("jc_auth_type", JC_AUTH_TYPE_API_KEY)
+        jc_multi_org = parse_jc_multi_org_flag(os.environ.get("jc_multi_org"))
     except KeyError as e:
         print(f"Missing environment variable: {e}")
         raise Exception(e)
 
-    jc_org_id = ""
-    if jc_org_id_secret_name:
-        fetched_id = get_secret(project_id, jc_org_id_secret_name).strip()
-        if fetched_id:
-            jc_org_id = fetched_id
+    pubsub_message = base64.b64decode(event['data']).decode('utf-8')
+    payload = json.loads(pubsub_message)
+    print(f"Received Job Payload: {payload}")
+
+    if "org_id" in payload:
+        _oid = payload.get("org_id")
+        jc_org_id = "" if _oid is None else str(_oid).strip()
+    elif jc_multi_org:
+        raise ValueError(
+            "Pub/Sub message is missing org_id; redeploy the orchestrator so each job includes org_id."
+        )
+    else:
+        jc_org_id = ""
+        if jc_org_id_secret_name:
+            fetched_id = get_secret(project_id, jc_org_id_secret_name).strip()
+            if fetched_id:
+                jc_org_id = fetched_id
 
     print("Worker building JumpCloud request headers (credentials from Secret Manager)...")
     try:
@@ -376,11 +426,6 @@ def jc_worker(event, context):
         print(f"JumpCloud OAuth or network error: {e}")
         raise Exception(e)
 
-    # Decode Pub/Sub message
-    pubsub_message = base64.b64decode(event['data']).decode('utf-8')
-    payload = json.loads(pubsub_message)
-    print(f"Received Job Payload: {payload}")
-    
     service = payload['service']
     start_date = payload['start_time']
     end_date = payload['end_time']
@@ -428,7 +473,8 @@ def jc_worker(event, context):
         return
         
     final_data.sort(key=lambda x: x['timestamp'], reverse=True)
-    out_file_name = f"jc_directoryinsights_{service}_{start_date}_{end_date}.json.gz"
+    org_prefix = f"{jc_org_id}_" if jc_org_id else ""
+    out_file_name = f"jc_directoryinsights_{org_prefix}{service}_{start_date}_{end_date}.json.gz"
     out_file_name = out_file_name.replace(":", "-") # Safe characters for Storage
     tmp_file_path = f"/tmp/{out_file_name}"
     

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -68,32 +68,20 @@ def _normalize_jc_auth_type(value):
     return str(value).strip()
 
 
-def get_jc_request_headers(project_id, api_key_secret_name, jc_org_id, auth_type):
+def prepare_jc_auth(project_id, api_key_secret_name, auth_type):
     """
-    Build HTTP headers for Insights API calls.
+    Load credential from Secret Manager once; for ServiceToken, exchange for an OAuth access token once.
 
-    - APIKey: secret is the JumpCloud API key; optional x-org-id when org secret is set.
-    - ServiceToken: secret is "clientID:clientSecret"; obtain OAuth access token via client_credentials,
-      then use Authorization: Bearer and x-org-id (org id required).
+    Use with build_jc_request_headers_from_prepared() per org so multi-org runs do not repeat Secret Manager
+    access or token round-trips (only x-org-id differs per organization).
     """
     auth_type = _normalize_jc_auth_type(auth_type)
     raw_secret = get_secret(project_id, api_key_secret_name).strip()
 
     if auth_type == JC_AUTH_TYPE_API_KEY:
-        headers = {
-            "x-api-key": raw_secret,
-            "content-type": "application/json",
-            "user-agent": JC_USER_AGENT,
-        }
-        if jc_org_id:
-            headers["x-org-id"] = jc_org_id
-        return headers
+        return {"kind": JC_AUTH_TYPE_API_KEY, "api_key": raw_secret}
 
     if auth_type == JC_AUTH_TYPE_SERVICE_TOKEN:
-        if not jc_org_id:
-            raise ValueError(
-                "ServiceToken auth requires an organization ID (jc_org_id / org secret)."
-            )
         if ":" not in raw_secret:
             raise ValueError(
                 'ServiceToken auth requires the api-key secret to be "clientID:clientSecret".'
@@ -113,14 +101,46 @@ def get_jc_request_headers(project_id, api_key_secret_name, jc_org_id, auth_type
         access_token = token_json.get("access_token")
         if not access_token:
             raise ValueError("OAuth token response missing access_token")
+        return {"kind": JC_AUTH_TYPE_SERVICE_TOKEN, "access_token": access_token}
+
+    raise ValueError(f"Unknown jc_auth_type: {auth_type!r}; use APIKey or ServiceToken.")
+
+
+def build_jc_request_headers_from_prepared(prepared, jc_org_id):
+    """Build request headers for one org from prepare_jc_auth() result (same credential, org-specific x-org-id)."""
+    kind = prepared["kind"]
+    if kind == JC_AUTH_TYPE_API_KEY:
+        headers = {
+            "x-api-key": prepared["api_key"],
+            "content-type": "application/json",
+            "user-agent": JC_USER_AGENT,
+        }
+        if jc_org_id:
+            headers["x-org-id"] = jc_org_id
+        return headers
+
+    if kind == JC_AUTH_TYPE_SERVICE_TOKEN:
+        if not jc_org_id:
+            raise ValueError(
+                "ServiceToken auth requires an organization ID (jc_org_id / org secret)."
+            )
         return {
-            "Authorization": f"Bearer {access_token}",
+            "Authorization": f"Bearer {prepared['access_token']}",
             "content-type": "application/json",
             "user-agent": JC_USER_AGENT,
             "x-org-id": jc_org_id,
         }
 
-    raise ValueError(f"Unknown jc_auth_type: {auth_type!r}; use APIKey or ServiceToken.")
+    raise ValueError(f"Unknown prepared auth kind: {kind!r}")
+
+
+def get_jc_request_headers(project_id, api_key_secret_name, jc_org_id, auth_type):
+    """
+    Build HTTP headers for Insights API calls (single org). Fetches secret once and obtains OAuth token once
+    when using ServiceToken — suitable for the Worker, which handles one org per invocation.
+    """
+    prepared = prepare_jc_auth(project_id, api_key_secret_name, auth_type)
+    return build_jc_request_headers_from_prepared(prepared, jc_org_id)
 
 
 def parse_jc_multi_org_flag(value):
@@ -326,20 +346,28 @@ def jc_orchestrator(request):
     # Create a list to track all of our Pub/Sub publish operations
     publish_futures = []
 
+    # One Secret Manager read + one OAuth token exchange (ServiceToken); per-org only varies x-org-id.
+    print("Preparing JumpCloud authentication (Secret Manager; OAuth if ServiceToken)...")
+    try:
+        jc_auth_prepared = prepare_jc_auth(
+            project_id, jc_api_key_secret_name, jc_auth_type
+        )
+    except ValueError as e:
+        print(str(e))
+        return str(e), 400
+    except requests.RequestException as e:
+        print(f"JumpCloud OAuth or network error: {e}")
+        return f"Authentication failed: {e}", 502
+
     for org_id in org_ids:
         org_label = mask_org_id_for_logs(org_id)
         print(f"[ORCHESTRATOR] Organization context: {org_label}")
 
         try:
-            headers = get_jc_request_headers(
-                project_id, jc_api_key_secret_name, org_id, jc_auth_type
-            )
+            headers = build_jc_request_headers_from_prepared(jc_auth_prepared, org_id)
         except ValueError as e:
             print(str(e))
             return str(e), 400
-        except requests.RequestException as e:
-            print(f"JumpCloud OAuth or network error: {e}")
-            return f"Authentication failed: {e}", 502
 
         for service in service_list:
             if service not in available_services:

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -145,6 +145,29 @@ def build_org_id_list(org_secret_raw, multi_org):
     return [""]
 
 
+def mask_org_id_for_logs(org_id):
+    """
+    Log-safe org ID: first four characters, remainder replaced with asterisks.
+    Does not alter values used for API calls, Pub/Sub payloads, or object names.
+    """
+    if org_id is None or str(org_id).strip() == "":
+        return "(no x-org-id)"
+    s = str(org_id).strip()
+    n = len(s)
+    show = min(4, n)
+    return s[:show] + "*" * (n - show)
+
+
+def mask_org_id_in_text(text, org_id):
+    """Replace a literal org id in a string once (e.g. log line that echoes a filename)."""
+    if not org_id or not text:
+        return text
+    oid = str(org_id).strip()
+    if not oid:
+        return text
+    return text.replace(oid, mask_org_id_for_logs(oid), 1)
+
+
 def get_cron_time(cron_expression, time_tolerance):
     """Calculates the current and previous cron execution times."""
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -304,7 +327,7 @@ def jc_orchestrator(request):
     publish_futures = []
 
     for org_id in org_ids:
-        org_label = org_id if org_id else "(no x-org-id)"
+        org_label = mask_org_id_for_logs(org_id)
         print(f"[ORCHESTRATOR] Organization context: {org_label}")
 
         try:
@@ -398,7 +421,10 @@ def jc_worker(event, context):
 
     pubsub_message = base64.b64decode(event['data']).decode('utf-8')
     payload = json.loads(pubsub_message)
-    print(f"Received Job Payload: {payload}")
+    _log_payload = dict(payload)
+    if "org_id" in _log_payload:
+        _log_payload["org_id"] = mask_org_id_for_logs(_log_payload.get("org_id"))
+    print(f"Received Job Payload: {_log_payload}")
 
     if "org_id" in payload:
         _oid = payload.get("org_id")
@@ -495,8 +521,9 @@ def jc_worker(event, context):
         print(f"Error compressing file: {e}")
         raise Exception(e)
 
-    # Upload to Cloud Storage
-    print(f"Uploading {out_file_name} to Cloud Storage bucket: {bucket_name}...")
+    # Upload to Cloud Storage (log line masks org segment; object name remains full org id)
+    _log_object_name = mask_org_id_in_text(out_file_name, jc_org_id)
+    print(f"Uploading {_log_object_name} to Cloud Storage bucket: {bucket_name}...")
     try:
         client = storage.Client()
         bucket = client.bucket(bucket_name)

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -55,6 +55,74 @@ def get_secret(project_id, secret_name):
         print(f"Error retrieving secret: {e}")
         raise Exception(e)
 
+# JumpCloud Directory Insights auth: API key (x-api-key) or OAuth client credentials (Bearer + x-org-id).
+JC_AUTH_TYPE_API_KEY = "APIKey"
+JC_AUTH_TYPE_SERVICE_TOKEN = "ServiceToken"
+JC_OAUTH_TOKEN_URL = "https://admin-oauth.id.jumpcloud.com/oauth2/token"
+JC_USER_AGENT = "JumpCloud_GCPServerless.DirectoryInsights/3.0.0"
+
+
+def _normalize_jc_auth_type(value):
+    if value is None or str(value).strip() == "":
+        return JC_AUTH_TYPE_API_KEY
+    return str(value).strip()
+
+
+def get_jc_request_headers(project_id, api_key_secret_name, jc_org_id, auth_type):
+    """
+    Build HTTP headers for Insights API calls.
+
+    - APIKey: secret is the JumpCloud API key; optional x-org-id when org secret is set.
+    - ServiceToken: secret is "clientID:clientSecret"; obtain OAuth access token via client_credentials,
+      then use Authorization: Bearer and x-org-id (org id required).
+    """
+    auth_type = _normalize_jc_auth_type(auth_type)
+    raw_secret = get_secret(project_id, api_key_secret_name).strip()
+
+    if auth_type == JC_AUTH_TYPE_API_KEY:
+        headers = {
+            "x-api-key": raw_secret,
+            "content-type": "application/json",
+            "user-agent": JC_USER_AGENT,
+        }
+        if jc_org_id:
+            headers["x-org-id"] = jc_org_id
+        return headers
+
+    if auth_type == JC_AUTH_TYPE_SERVICE_TOKEN:
+        if not jc_org_id:
+            raise ValueError(
+                "ServiceToken auth requires an organization ID (jc_org_id / org secret)."
+            )
+        if ":" not in raw_secret:
+            raise ValueError(
+                'ServiceToken auth requires the api-key secret to be "clientID:clientSecret".'
+            )
+        basic_b64 = base64.b64encode(raw_secret.encode("utf-8")).decode("ascii")
+        token_resp = requests.post(
+            JC_OAUTH_TOKEN_URL,
+            data={"scope": "api", "grant_type": "client_credentials"},
+            headers={
+                "Authorization": f"Basic {basic_b64}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            timeout=60,
+        )
+        token_resp.raise_for_status()
+        token_json = token_resp.json()
+        access_token = token_json.get("access_token")
+        if not access_token:
+            raise ValueError("OAuth token response missing access_token")
+        return {
+            "Authorization": f"Bearer {access_token}",
+            "content-type": "application/json",
+            "user-agent": JC_USER_AGENT,
+            "x-org-id": jc_org_id,
+        }
+
+    raise ValueError(f"Unknown jc_auth_type: {auth_type!r}; use APIKey or ServiceToken.")
+
+
 def get_cron_time(cron_expression, time_tolerance):
     """Calculates the current and previous cron execution times."""
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -136,6 +204,7 @@ def jc_orchestrator(request):
         cron_schedule = os.environ['cron_schedule']
         topic_name = os.environ['pubsub_topic']
         service_env = os.environ['service']
+        jc_auth_type = os.environ.get("jc_auth_type", JC_AUTH_TYPE_API_KEY)
         print("Environment variables loaded successfully.")
     except KeyError as e:
         print(f"Missing env var: {e}")
@@ -151,16 +220,25 @@ def jc_orchestrator(request):
         print(f"[MANUAL] Overriding default service with: {test_service}")
         service_env = test_service
 
-    print("Fetching API Key from Secret Manager...")
-    jcapikey = get_secret(project_id, jc_api_key_secret_name)
-    
-    jc_org_id = "" 
+    jc_org_id = ""
     if jc_org_id_secret_name:
         print("Fetching Org ID from Secret Manager...")
         fetched_id = get_secret(project_id, jc_org_id_secret_name).strip()
         if fetched_id:
             jc_org_id = fetched_id
-            print(f"Org ID loaded")
+            print("Org ID loaded")
+
+    print("Building JumpCloud request headers (credentials from Secret Manager)...")
+    try:
+        headers = get_jc_request_headers(
+            project_id, jc_api_key_secret_name, jc_org_id, jc_auth_type
+        )
+    except ValueError as e:
+        print(str(e))
+        return str(e), 400
+    except requests.RequestException as e:
+        print(f"JumpCloud OAuth or network error: {e}")
+        return f"Authentication failed: {e}", 502
 
     # --- Time window: explicit [start_time, end_time] OR cron schedule ---
     has_start = raw_start is not None and str(raw_start).strip() != ""
@@ -199,14 +277,6 @@ def jc_orchestrator(request):
     if 'all' in service_list and len(service_list) > 1:
         print("Configuration contains 'all' alongside specific services. Defaulting to 'all'.")
         service_list = ['all']
-    
-    headers = {
-        'x-api-key': jcapikey,
-        'content-type': "application/json",
-        'user-agent': "JumpCloud_GCPServerless.DirectoryInsights/3.0.0"
-    }
-    if jc_org_id != '':                 
-        headers['x-org-id'] = jc_org_id
 
     # Grab the max events from the environment, defaulting to 25000 if not set
     MAX_EVENTS_PER_WORKER = int(os.environ.get('max_events_per_worker', 25000)) 
@@ -283,18 +353,28 @@ def jc_worker(event, context):
         bucket_name = os.environ['bucket_name']
         jc_org_id_secret_name = os.environ.get('jc_org_id', '')
         json_format = os.environ.get('json_format', 'MultiLine') # MultiLine, SingleLine, or NDJson
+        jc_auth_type = os.environ.get("jc_auth_type", JC_AUTH_TYPE_API_KEY)
     except KeyError as e:
         print(f"Missing environment variable: {e}")
         raise Exception(e)
 
-    print("Worker fetching API Key from Secret Manager...")
-    jcapikey = get_secret(project_id, jc_api_key_secret_name)
-    
-    jc_org_id = "" 
+    jc_org_id = ""
     if jc_org_id_secret_name:
         fetched_id = get_secret(project_id, jc_org_id_secret_name).strip()
         if fetched_id:
             jc_org_id = fetched_id
+
+    print("Worker building JumpCloud request headers (credentials from Secret Manager)...")
+    try:
+        headers = get_jc_request_headers(
+            project_id, jc_api_key_secret_name, jc_org_id, jc_auth_type
+        )
+    except ValueError as e:
+        print(str(e))
+        raise Exception(e)
+    except requests.RequestException as e:
+        print(f"JumpCloud OAuth or network error: {e}")
+        raise Exception(e)
 
     # Decode Pub/Sub message
     pubsub_message = base64.b64decode(event['data']).decode('utf-8')
@@ -312,15 +392,7 @@ def jc_worker(event, context):
         'end_time': end_date,
         "limit": 10000
     }
-    
-    headers = {
-        'x-api-key': jcapikey,
-        'content-type': "application/json",
-        'user-agent': "JumpCloud_GCPServerless.DirectoryInsights/3.0.0"
-    }
-    if jc_org_id != '':
-        headers['x-org-id'] = jc_org_id
-        
+
     final_data = []
     
     print(f"[WORKER] Querying Events URL: {url}")


### PR DESCRIPTION
## Issues
* [CUT-5112](https://jumpcloud.atlassian.net/browse/CUT-5112) - Service Token Authorization
* [CUT-5115](https://jumpcloud.atlassian.net/browse/CUT-5115) - Multi-Org Support (Enterprise Organizations)

## What does this solve?

Two issues, the addition of service account credentialing instead of API key. This allows customers to scope credentials to just a read only DI role and create a service token for just this tool. 

Also included is the Multi-Org support for MTP admins or some Enterprise Portal customer who wishes to get data about many of their orgs at once without multiple deployments. 

This creates a bucket item per org, per timestamp.

## Is there anything particularly tricky?

Review of the implementation of MultiOrg support.

## How should this be tested?

Test with a service account token, test with MTP & multiple organizations:
When multiple orgs have data in a given timeslot: their orgID will be in the bucket name item
<img width="731" height="95" alt="Screenshot 2026-04-10 at 2 27 32 PM" src="https://github.com/user-attachments/assets/64016985-cdbc-4db6-bd67-fe7a19bf0317" />

The orchestrator will process each org events separate 
<img width="1221" height="682" alt="Screenshot 2026-04-13 at 12 47 07 PM" src="https://github.com/user-attachments/assets/9afec8f6-dba3-4c36-8846-d49cc24ea370" />


## Screenshots


[CUT-5112]: https://jumpcloud.atlassian.net/browse/CUT-5112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CUT-5115]: https://jumpcloud.atlassian.net/browse/CUT-5115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new OAuth client-credential authentication and multi-organization scoping to the Orchestrator/Worker, which changes how credentials are used and how tenant data is partitioned in storage and Pub/Sub.
> 
> **Overview**
> Adds **ServiceToken (OAuth client credentials)** support alongside API-key auth for Directory Insights, including runtime token exchange and updated request header construction.
> 
> Introduces **multi-org mode**: the Orchestrator iterates a comma-separated org list, publishes jobs with an `org_id`, and the Worker uses that org context for API calls and prefixes GCS object names to avoid collisions; logs now mask org IDs.
> 
> Updates `cloudbuild.yaml` to add `_JC_AUTH_TYPE`/`_JC_MULTI_ORG`, validate substitutions, pass new env vars to functions, and **create or version-bump** Secret Manager secrets on each build; documentation/changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcdf84d880ca6fcff47f601eef97514a273a777a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->