### PR TITLE
Cut 5113 Service Token and MultiOrg Support

### DIFF
--- a/AWS/DirectoryInsights/CHANGELOG.md
+++ b/AWS/DirectoryInsights/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.0] - 2026-03-20
+
+### Added
+
+- Test functionality to input start, end time, and directory
+- Multi Org and Service account support 
 ## [3.0.0] - 2026-03-20
 
 ### Added

--- a/AWS/DirectoryInsights/README.md
+++ b/AWS/DirectoryInsights/README.md
@@ -16,6 +16,7 @@ _Note: This document assumes the use of Python 3.14+_
     - [Packaging the Application](#packaging-the-application)
     - [Deploying the Application](#deploying-the-application)
     - [Formatting JSON](#formatting-json)
+    - [Multiple Organizations](#multiple-organizations)
   - [Updating an Existing Deployment](#updating-an-existing-deployment)
   - [Clean Up / Uninstall](#clean-up--uninstall)
   - [Note on Data Chunking (MAX\_EVENTS\_PER\_WORKER)](#note-on-data-chunking-max_events_per_worker)
@@ -145,6 +146,25 @@ SingleLine Format:
 ![Alt text](image-2.png)
 MultiLine Format:
 ![Alt text](image-1.png)
+
+### Multiple Organizations
+Enterprise customers may use one API key or one OAuth client (Service Account Token) to access several JumpCloud organizations at once.
+
+Create a Secret in AWS Secrets Manager that contains a comma-separated list of your target organization IDs (e.g., orgId1,orgId2,orgId3).
+
+1. Set the JcMultiOrg parameter to true when deploying the CloudFormation stack.
+
+2. Set the OrganizationID parameter, `(e.g., orgId1,orgId2,orgId3)`.
+
+**Behavior**
+
+- The Orchestrator loops through each org: it builds request headers for that org, calls the /insights/directory/v1/events/count endpoint per org and service, splits time ranges when needed, and enqueues one SQS message per chunk. Each message includes an org_id field so the Worker knows which tenant to query.
+
+- The Worker reads the org_id from the SQS message to target the correct organization.
+
+- Uploaded files are automatically named so different orgs do not overwrite each other:
+
+`jc_directoryinsights_<orgId>_<service>_<start>_<end>.json.gz`
 
 ## Updating an Existing Deployment
 To update your existing application to a newer version, simply pull the latest code, re-package the ZIP file, and run the `sam package` and `aws cloudformation deploy` commands again using the **exact same `--stack-name`**. AWS CloudFormation will automatically detect the changes and safely update your existing resources.

--- a/AWS/DirectoryInsights/get-jcdirectoryinsights.py
+++ b/AWS/DirectoryInsights/get-jcdirectoryinsights.py
@@ -27,7 +27,7 @@ def get_secret(secret_id, suppress_error=False):
         return response['SecretString']
     except ClientError as e:
         if not suppress_error:
-            logger.error(f"Error retrieving secret {secret_id}: {e}")
+            logger.error("Error retrieving secret from AWS Secrets Manager.")
         raise Exception(e)
 
 JC_AUTH_TYPE_API_KEY = "APIKey"

--- a/AWS/DirectoryInsights/get-jcdirectoryinsights.py
+++ b/AWS/DirectoryInsights/get-jcdirectoryinsights.py
@@ -1,36 +1,130 @@
-import os, json, boto3, requests, gzip, logging, datetime, math
+import os
+import json
+import boto3
+import requests
+import gzip
+import logging
+import datetime
+import math
+import base64
+import re
 from botocore.exceptions import ClientError
 from croniter import croniter
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-def get_secret(secret_name):
+# ==============================================================================
+# CORE HELPER FUNCTIONS
+# ==============================================================================
+def get_secret(secret_id, suppress_error=False):
     """Retrieves the secret value from AWS Secrets Manager."""
+    if not secret_id:
+        return ""
     client = boto3.client(service_name='secretsmanager')
     try:
-        response = client.get_secret_value(SecretId=secret_name)
+        response = client.get_secret_value(SecretId=secret_id)
         return response['SecretString']
     except ClientError as e:
-        logger.error(f"Error retrieving secret: {e}")
+        if not suppress_error:
+            logger.error(f"Error retrieving secret {secret_id}: {e}")
         raise Exception(e)
+
+JC_AUTH_TYPE_API_KEY = "APIKey"
+JC_AUTH_TYPE_SERVICE_TOKEN = "ServiceToken"
+JC_OAUTH_TOKEN_URL = "https://admin-oauth.id.jumpcloud.com/oauth2/token"
+JC_USER_AGENT = "JumpCloud_AWSServerless.DirectoryInsights/3.1.0"
+
+def _normalize_jc_auth_type(value):
+    if value is None or str(value).strip() == "":
+        return JC_AUTH_TYPE_API_KEY
+    return str(value).strip()
+
+def prepare_jc_auth(secret_arn, auth_type):
+    """Load credential from Secrets Manager once; for ServiceToken, exchange for OAuth access token."""
+    auth_type = _normalize_jc_auth_type(auth_type)
+    raw_secret = get_secret(secret_arn).strip()
+
+    if auth_type == JC_AUTH_TYPE_API_KEY:
+        return {"kind": JC_AUTH_TYPE_API_KEY, "api_key": raw_secret}
+
+    if auth_type == JC_AUTH_TYPE_SERVICE_TOKEN:
+        if ":" not in raw_secret:
+            raise ValueError('ServiceToken auth requires the api-key secret to be "clientID:clientSecret".')
+        basic_b64 = base64.b64encode(raw_secret.encode("utf-8")).decode("ascii")
+        token_resp = requests.post(
+            JC_OAUTH_TOKEN_URL,
+            data={"scope": "api", "grant_type": "client_credentials"},
+            headers={
+                "Authorization": f"Basic {basic_b64}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            timeout=60,
+        )
+        token_resp.raise_for_status()
+        token_json = token_resp.json()
+        access_token = token_json.get("access_token")
+        if not access_token:
+            raise ValueError("OAuth token response missing access_token")
+        return {"kind": JC_AUTH_TYPE_SERVICE_TOKEN, "access_token": access_token}
+
+    raise ValueError(f"Unknown JcAuthType: {auth_type!r}; use APIKey or ServiceToken.")
+
+def build_jc_request_headers_from_prepared(prepared, jc_org_id):
+    """Build request headers for one org from prepare_jc_auth() result."""
+    kind = prepared["kind"]
+    if kind == JC_AUTH_TYPE_API_KEY:
+        headers = {
+            "x-api-key": prepared["api_key"],
+            "content-type": "application/json",
+            "user-agent": JC_USER_AGENT,
+        }
+        if jc_org_id:
+            headers["x-org-id"] = jc_org_id
+        return headers
+
+    if kind == JC_AUTH_TYPE_SERVICE_TOKEN:
+        if not jc_org_id:
+            raise ValueError("ServiceToken auth requires an organization ID.")
+        return {
+            "Authorization": f"Bearer {prepared['access_token']}",
+            "content-type": "application/json",
+            "user-agent": JC_USER_AGENT,
+            "x-org-id": jc_org_id,
+        }
+
+    raise ValueError(f"Unknown prepared auth kind: {kind!r}")
+
+def parse_jc_multi_org_flag(value):
+    if value is None:
+        return False
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+def build_org_id_list(org_secret_raw, multi_org):
+    raw = (org_secret_raw or "").strip()
+    if multi_org:
+        return [p.strip() for p in raw.split(",") if p.strip()]
+    if raw:
+        return [raw]
+    return [""]
+
+def mask_org_id_for_logs(org_id):
+    if org_id is None or str(org_id).strip() == "":
+        return "(no x-org-id)"
+    s = str(org_id).strip()
+    if len(s) <= 4:
+        return s
+    return "*" * (len(s) - 4) + s[-4:]
 
 def get_cron_time(cronExpression, timeTolerance):
     """Checks if the current time is within a tolerance of the cron schedule."""
-    # Use UTC explicitly to prevent timezone mismatch
     now = datetime.datetime.now(datetime.timezone.utc)
     cronParts = cronExpression.split()
     cronExpression = " ".join(cronParts[:5])
     try:
-        # Add the tolerance (instead of subtracting) in case EventBridge fires a few seconds late
         cronTime = croniter(cronExpression, now + datetime.timedelta(seconds=timeTolerance))
-        
-        # Get the most recent scheduled cron tick (e.g. 18:50:00)
         currentCronTime = cronTime.get_prev(datetime.datetime)
-        
-        # Get the scheduled cron tick right before that one (e.g. 18:45:00)
         previousCronTime = cronTime.get_prev(datetime.datetime)
-        
         return currentCronTime, previousCronTime
     except Exception as e:
         logger.error(f"Error in cron expression: {e}")
@@ -41,117 +135,230 @@ def chunk_time_range(start_time, end_time, chunks):
     delta = (end_time - start_time) / chunks
     return [(start_time + delta * i, start_time + delta * (i + 1)) for i in range(chunks)]
 
+
+def parse_utc_datetime(value):
+    """
+    Parse start_time / end_time from Event JSON.
+
+    Dynamic (evaluated at request time, UTC):
+      - "now" — current instant
+      - "now-30" or "now-30d" — 30 days before now (suffix: d=days, h=hours, m=minutes, s=seconds; bare number = days)
+
+    Fixed: ISO-8601, or YYYY-MM-DD:HH:MM:SS. Naive values are UTC.
+    """
+    if value is None:
+        raise ValueError("Timestamp is missing")
+    s_raw = str(value).strip()
+    if not s_raw:
+        raise ValueError("Timestamp is empty")
+
+    s_key = s_raw.lower()
+    utc = datetime.timezone.utc
+    now = datetime.datetime.now(utc)
+
+    if s_key == "now":
+        return now
+
+    rel = re.match(r"^now-(\d+)([dhms])?$", s_key)
+    if rel:
+        n = int(rel.group(1))
+        unit = rel.group(2) or "d"
+        if unit == "d":
+            delta = datetime.timedelta(days=n)
+        elif unit == "h":
+            delta = datetime.timedelta(hours=n)
+        elif unit == "m":
+            delta = datetime.timedelta(minutes=n)
+        else:
+            delta = datetime.timedelta(seconds=n)
+        return now - delta
+
+    s = s_raw
+    if len(s) > 10 and s[10] == ":":
+        s = s[:10] + "T" + s[11:]
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    dt = datetime.datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=utc)
+    else:
+        dt = dt.astimezone(utc)
+    return dt
+
 # ==============================================================================
 # ORCHESTRATOR FUNCTION
 # ==============================================================================
 def jc_orchestrator(event, context):
+    logger.info("--- ORCHESTRATOR STARTED ---")
     try:
         jcapikeyarn = os.environ['JcApiKeyArn']
-        orgId = os.environ.get('OrgId', '')
+        org_env_var = os.environ.get('OrgId', '')
         cronExpression = os.environ['CronExpression']
         queueUrl = os.environ['SqsQueueUrl']
         service_env = os.environ['service']
+        jc_auth_type = os.environ.get("JcAuthType", JC_AUTH_TYPE_API_KEY)
+        jc_multi_org = parse_jc_multi_org_flag(os.environ.get("JcMultiOrg"))
+        MAX_EVENTS_PER_WORKER = int(os.environ.get('MaxEventsPerWorker', 25000))
     except KeyError as e:
         logger.error(f"Missing env var: {e}")
         raise Exception(e)
 
-    jcapikey = get_secret(jcapikeyarn)
-    timeTolerance = 10
-    now, previousTime = get_cron_time(cronExpression, timeTolerance)
+    # --- Optional JSON: explicit window (start_time + end_time) or service override ---
+    raw_start = event.get("start_time")
+    raw_end = event.get("end_time")
+    test_service = event.get("service")
+
+    if test_service:
+        logger.info(f"[MANUAL] Overriding default service with: {test_service}")
+        service_env = test_service
+
+    # Attempt to fetch Org IDs. Suppress error so a plain string doesn't trigger a CloudWatch alert.
+    org_secret_raw = ""
+    if org_env_var:
+        try:
+            org_secret_raw = get_secret(org_env_var, suppress_error=True).strip()
+        except Exception:
+            logger.info("OrgId does not map to an AWS Secret; treating as a literal string.")
+            org_secret_raw = org_env_var
+
+    org_ids = build_org_id_list(org_secret_raw, jc_multi_org)
+    
+    if jc_multi_org and not org_ids:
+        error_msg = "JcMultiOrg is true but no organization IDs were found."
+        logger.error(error_msg)
+        return {"statusCode": 400, "body": error_msg}
+
+    # --- Time window: explicit [start_time, end_time] OR cron schedule ---
+    has_start = raw_start is not None and str(raw_start).strip() != ""
+    has_end = raw_end is not None and str(raw_end).strip() != ""
+
+    if has_start ^ has_end:
+        error_msg = "Provide both start_time and end_time for a manual window, or omit both for scheduled (cron) mode."
+        logger.error(error_msg)
+        return {"statusCode": 400, "body": error_msg}
+
+    if has_start and has_end:
+        try:
+            previousTime = parse_utc_datetime(raw_start)
+            now = parse_utc_datetime(raw_end)
+        except ValueError as e:
+            error_msg = f"Invalid start_time or end_time: {e}"
+            logger.error(error_msg)
+            return {"statusCode": 400, "body": error_msg}
+        if previousTime >= now:
+            error_msg = "start_time must be strictly before end_time."
+            logger.error(error_msg)
+            return {"statusCode": 400, "body": error_msg}
+        logger.info(f"[MANUAL WINDOW] {previousTime.isoformat()} to {now.isoformat()}")
+    else:
+        timeTolerance = 10
+        now, previousTime = get_cron_time(cronExpression, timeTolerance)
+        logger.info(f"Search Window: {previousTime} to {now}")
     
     sqs = boto3.client('sqs')
-    
     availableServices = ['all', 'access_management', 'alerts', 'asset_management', 'directory', 'ldap', 'mdm', 'notifications', 'object_storage', 'password_manager', 'radius', 'reports', 'saas_app_management', 'software', 'sso', 'systems', 'workflows']
     serviceList = ((service_env.replace(" ", "")).lower()).split(",")
     
-    # If 'all' is in the list, just use 'all' and drop the duplicates
     if 'all' in serviceList and len(serviceList) > 1:
-        logger.warning("Configuration contains 'all' alongside specific services. Defaulting to 'all' to prevent duplicate data ingestion.")
+        logger.warning("Configuration contains 'all' alongside specific services. Defaulting to 'all'.")
         serviceList = ['all']
-    
-    headers = {
-        'x-api-key': jcapikey,
-        'content-type': "application/json",
-        'user-agent': "JumpCloud_AWSServerless.DirectoryInsights/3.0.0"
-    }
-    # Inject the OrgId into the headers if it exists
-    if orgId != '':                 
-        headers['x-org-id'] = orgId
 
-    MAX_EVENTS_PER_WORKER = 25000
+    logger.info("Preparing JumpCloud authentication...")
+    try:
+        jc_auth_prepared = prepare_jc_auth(jcapikeyarn, jc_auth_type)
+    except Exception as e:
+        logger.error(f"Auth prep failed: {e}")
+        raise Exception(e)
 
-    for service in serviceList:
-        if service not in availableServices:
-            logger.error(f"Unknown service: {service}")
-            continue
-
-        start_iso = previousTime.isoformat("T").replace("+00:00", "Z")
-        end_iso = now.isoformat("T").replace("+00:00", "Z")
-        
-        # Hit the count endpoint to see if we even need to pull data
-        count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
-        count_body = {'service': [service], 'start_time': start_iso, 'end_time': end_iso}
+    for org_id in org_ids:
+        org_label = mask_org_id_for_logs(org_id)
+        logger.info(f"[ORCHESTRATOR] Organization context: {org_label}")
         
         try:
-            response = requests.post(count_url, json=count_body, headers=headers)
-            response.raise_for_status()
-            total_events = json.loads(response.text).get('count', 0)
-            # Count log
-            logger.info(f"Total events for {service}: {total_events}")
-        
-        except Exception as e:
-            logger.warning(f"Failed to get event count for {service}: {e}")
-            logger.info("Defaulting to queueing the full time slice to let SQS handle retries.")
-            total_events = MAX_EVENTS_PER_WORKER # Forces the math below to create exactly 1 chunk
-        
-        if total_events == 0:
-            logger.info(f"No events for {service} between {start_iso} and {end_iso}. Skipping.")
-            continue 
+            headers = build_jc_request_headers_from_prepared(jc_auth_prepared, org_id)
+        except ValueError as e:
+            logger.error(str(e))
+            continue
 
-        # Slice the time if there are too many events
-        num_chunks = max(1, math.ceil(total_events / MAX_EVENTS_PER_WORKER))
-        time_slices = chunk_time_range(previousTime, now, num_chunks)
-        logger.info(f"Chunks: {num_chunks}")
-        logger.info(f"Slices: {time_slices}")
-        
-        
-        # Queue the jobs into SQS
-        for slice_start, slice_end in time_slices:
-            message_body = {
-                'service': service,
-                'start_time': slice_start.isoformat("T").replace("+00:00", "Z"),
-                'end_time': slice_end.isoformat("T").replace("+00:00", "Z")
-            }
-            sqs.send_message(
-                QueueUrl=queueUrl,
-                MessageBody=json.dumps(message_body)
-            )
-            logger.info(f"Queued job for {service}: {message_body['start_time']} to {message_body['end_time']}")
+        for service in serviceList:
+            if service not in availableServices:
+                logger.error(f"Unknown service: {service}")
+                continue
 
+            start_iso = previousTime.isoformat("T").replace("+00:00", "Z")
+            end_iso = now.isoformat("T").replace("+00:00", "Z")
+            
+            count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
+            count_body = {'service': [service], 'start_time': start_iso, 'end_time': end_iso}
+            
+            try:
+                response = requests.post(count_url, json=count_body, headers=headers)
+                response.raise_for_status()
+                total_events = json.loads(response.text).get('count', 0)
+                logger.info(f"Total events for org {org_label} | {service}: {total_events}")
+            except Exception as e:
+                logger.warning(f"Failed to get event count for org {org_label} | {service}: {e}")
+                total_events = MAX_EVENTS_PER_WORKER 
+            
+            if total_events == 0:
+                logger.info(f"No events for org {org_label} | {service} between {start_iso} and {end_iso}. Skipping.")
+                continue 
+
+            num_chunks = max(1, math.ceil(total_events / MAX_EVENTS_PER_WORKER))
+            time_slices = chunk_time_range(previousTime, now, num_chunks)
+            
+            for slice_start, slice_end in time_slices:
+                message_body = {
+                    'service': service,
+                    'start_time': slice_start.isoformat("T").replace("+00:00", "Z"),
+                    'end_time': slice_end.isoformat("T").replace("+00:00", "Z"),
+                    'org_id': org_id
+                }
+                sqs.send_message(
+                    QueueUrl=queueUrl,
+                    MessageBody=json.dumps(message_body)
+                )
+                logger.info(f"Queued job for org={org_label} | {service}: {message_body['start_time']} to {message_body['end_time']}")
+
+    logger.info("--- ORCHESTRATOR COMPLETE ---")
     return {"statusCode": 200, "body": "Orchestration complete"}
 
 # ==============================================================================
 # WORKER FUNCTION
 # ==============================================================================
 def jc_worker(event, context):
+    logger.info("--- WORKER STARTED ---")
     try:
         jcapikeyarn = os.environ['JcApiKeyArn']
         bucketName = os.environ['BucketName']
-        orgId = os.environ.get('OrgId', '')
         JsonFormat = os.environ.get('JsonFormat', 'MultiLine')
+        jc_auth_type = os.environ.get("JcAuthType", JC_AUTH_TYPE_API_KEY)
     except KeyError as e:
         logger.error(f"Missing environment variable: {e}")
         raise Exception(e)
 
-    jcapikey = get_secret(jcapikeyarn)
+    logger.info("Worker preparing JumpCloud authentication...")
+    try:
+        jc_auth_prepared = prepare_jc_auth(jcapikeyarn, jc_auth_type)
+    except Exception as e:
+        logger.error(f"Auth prep failed: {e}")
+        raise Exception(e)
     
     for record in event['Records']:
         payload = json.loads(record['body'])
         service = payload['service']
         startDate = payload['start_time']
         endDate = payload['end_time']
+        org_id = payload.get('org_id', '')
         
-        logger.info(f"Processing {service} from {startDate} to {endDate}")
+        org_label = mask_org_id_for_logs(org_id)
+        logger.info(f"Processing org={org_label} | {service} from {startDate} to {endDate}")
+
+        try:
+            headers = build_jc_request_headers_from_prepared(jc_auth_prepared, org_id)
+        except ValueError as e:
+            logger.error(str(e))
+            raise Exception(e)
 
         url = "https://api.jumpcloud.com/insights/directory/v1/events"
         body = {
@@ -160,15 +367,6 @@ def jc_worker(event, context):
             'end_time': endDate,
             "limit": 10000
         }
-        
-        headers = {
-            'x-api-key': jcapikey,
-            'content-type': "application/json",
-            'user-agent': "JumpCloud_AWSServerless.DirectoryInsights/3.0.0"
-        }
-        if orgId != '':
-            headers['x-org-id'] = orgId
-            
         finalData = []
         
         try:
@@ -179,12 +377,11 @@ def jc_worker(event, context):
             raise Exception(e)
             
         if response.text.strip() == "[]":
-            logger.info(f"No results found for {service} in this time slice.")
+            logger.info(f"No results found for org={org_label} | {service} in this time slice.")
             continue
             
         data = json.loads(response.text)
         
-        # Paginate if needed
         while int(response.headers.get("X-Result-Count", 0)) >= int(response.headers.get("X-Limit", 10000)):
             body["search_after"] = json.loads(response.headers["X-Search_After"])
             response = requests.post(url, json=body, headers=headers)
@@ -197,8 +394,10 @@ def jc_worker(event, context):
             continue
             
         finalData.sort(key=lambda x: x['timestamp'], reverse=True)
-        outfileName = f"jc_directoryinsights_{service}_{startDate}_{endDate}.json.gz"
-        outfileName = outfileName.replace(":", "-") # Safe characters for S3
+        
+        org_prefix = f"{org_id}_" if org_id else ""
+        outfileName = f"jc_directoryinsights_{org_prefix}{service}_{startDate}_{endDate}.json.gz"
+        outfileName = outfileName.replace(":", "-")
         tmpFilePath = f"/tmp/{outfileName}"
         
         try:
@@ -214,9 +413,11 @@ def jc_worker(event, context):
         try:
             s3 = boto3.client('s3')
             s3.upload_file(tmpFilePath, bucketName, outfileName)
-            logger.info(f"Successfully uploaded {outfileName} to {bucketName}")
+            _log_object_name = mask_org_id_for_logs(org_id) + outfileName.split(org_id)[-1] if org_id else outfileName
+            logger.info(f"Successfully uploaded {_log_object_name} to {bucketName}")
         except ClientError as e:
             logger.error(f"Error uploading to S3: {e}")
             raise Exception(e)
             
+    logger.info("--- WORKER COMPLETE ---")
     return {"statusCode": 200, "body": "Worker process complete"}

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -219,7 +219,7 @@ Resources:
       Handler: get-jcdirectoryinsights.jc_worker
       MemorySize: 512
       Timeout: 900
-      Runtime: python3.12
+      Runtime: python3.14
       Role: !GetAtt WorkerRole.Arn
       KmsKeyArn: !GetAtt DirectoryInsightsCmk.Arn
       Environment:

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
 Parameters:
@@ -6,14 +6,29 @@ Parameters:
     Type: String
     NoEcho: true
     MinLength: 1
+    Description: 'Your JumpCloud API Key, or your Service Account credentials (secretID:secretToken) if using ServiceToken auth.'
+  JcAuthType:
+    Type: String
+    AllowedValues:
+      - APIKey
+      - ServiceToken
+    Default: APIKey
+    Description: 'Authentication method to use. ServiceToken performs an OAuth 2.0 exchange.'
   CronExpression:
     Type: String
-    Default: '0 0 * * ? *'  # Default to every day at midnight
-    Description: Cron expression for the schedule (e.g., "0 0 * * ? *").
+    Default: '0 0 * * ? *'  
+    Description: 'Cron expression for the schedule (e.g., "0 0 * * ? *"). Default to every day at midnight.'
   OrganizationID:
     Type: String
     Default: ''
-    Description: OPTIONAL - This parameter can be used to allow MTP Admins to select which Organization they would like to collect Directory Insights data for.
+    Description: 'OPTIONAL - A specific Org ID string, or the ARN of an AWS Secret containing a comma-separated list of Org IDs (requires JcMultiOrg=true).'
+  JcMultiOrg:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: 'Set to true if OrganizationID points to an AWS Secret containing a comma-separated list of Organization IDs.'
   Service:
     Type: String
     Default: "all"
@@ -25,13 +40,17 @@ Parameters:
       - SingleLine
     Default: MultiLine
     Description: 'JSon output indent format - MultiLine or SingleLine'
+  MaxEventsPerWorker:
+    Type: Number
+    Default: 25000
+    Description: 'Maximum number of events a single worker will process before the orchestrator chunks the time window.'
 
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: JumpCloud-DirectoryInsights
     Description: This Serverless Application can be used to collect your JumpCloud Directory Insights data at a regular interval.
     Author: JumpCloud Solutions Architecture
-    SemanticVersion: 3.0.0
+    SemanticVersion: 3.1.0
     HomePageUrl: https://git.io/JJlrZ
     SourceCodeUrl: https://git.io/JJiMo
     LicenseUrl: LICENSE
@@ -76,7 +95,7 @@ Resources:
   JcApiKey:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: JumpCloud API Key
+      Description: JumpCloud API Key or OAuth Client Credentials
       SecretString: !Ref JumpCloudApiKey
 
   JcApiResourcePolicy:
@@ -84,7 +103,7 @@ Resources:
     Properties:
       SecretId: !Ref JcApiKey
       ResourcePolicy:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
         - Effect: Allow
           Principal:
@@ -116,7 +135,7 @@ Resources:
     Properties:
       Description: Role for the Orchestrator Lambda
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -127,11 +146,14 @@ Resources:
       Policies:
         - PolicyName: OrchestratorPermissions
           PolicyDocument:
-            Version: 2012-10-17
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action: sqs:SendMessage
                 Resource: !GetAtt JobQueue.Arn
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: "*" 
 
   OrchestratorFunction:
     Type: AWS::Serverless::Function
@@ -146,15 +168,19 @@ Resources:
       Environment:
         Variables:
           JcApiKeyArn: !Ref JcApiKey
+          JcAuthType: !Ref JcAuthType
           CronExpression: !Ref CronExpression
           service: !Sub ${Service}
           SqsQueueUrl: !Ref JobQueue
           OrgId: !Sub ${OrganizationID}
+          JcMultiOrg: !Ref JcMultiOrg
+          MaxEventsPerWorker: !Ref MaxEventsPerWorker
       Events:
         ScheduleDirectoryInsightsTrigger:
           Type: Schedule
           Properties:
             Schedule: !Sub "cron(${CronExpression})"
+            
   # ---------------------------------------------------------
   # Worker Role & Function
   # ---------------------------------------------------------
@@ -163,18 +189,18 @@ Resources:
     Properties:
       Description: Role for the Worker Lambda
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
               Service: lambda.amazonaws.com
             Action: 'sts:AssumeRole'
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AWSLambdaExecute # Grants S3 PUT and CloudWatch Logs
+        - arn:aws:iam::aws:policy/AWSLambdaExecute 
       Policies:
         - PolicyName: WorkerPermissions
           PolicyDocument:
-            Version: 2012-10-17
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -193,14 +219,14 @@ Resources:
       Handler: get-jcdirectoryinsights.jc_worker
       MemorySize: 512
       Timeout: 900
-      Runtime: python3.14
+      Runtime: python3.12
       Role: !GetAtt WorkerRole.Arn
       KmsKeyArn: !GetAtt DirectoryInsightsCmk.Arn
       Environment:
         Variables:
           JcApiKeyArn: !Ref JcApiKey
+          JcAuthType: !Ref JcAuthType
           BucketName: !Ref DirectoryInsightsBucket
-          OrgId: !Sub ${OrganizationID}
           JsonFormat: !Sub ${JsonFormat}
       Events:
         SQSTrigger:
@@ -208,6 +234,3 @@ Resources:
           Properties:
             Queue: !GetAtt JobQueue.Arn
             BatchSize: 1
-
-
-           

--- a/GCP/DirectoryInsights/README.md
+++ b/GCP/DirectoryInsights/README.md
@@ -21,11 +21,13 @@ _Note: This document assumes the use of Python 3.12 on GCP Cloud Functions_
 - [Edit `cloudbuild.yaml`](#edit-cloudbuildyaml)
 - [Cloud Build substitutions](#cloud-build-substitutions)
 - [Authentication: API key and service account (OAuth)](#authentication-api-key-and-service-account-oauth)
+    - [API key (`_JC_AUTH_TYPE`: `APIKey`)](#api-key-_jc_auth_type-apikey)
+    - [Service account / OAuth client credentials (`_JC_AUTH_TYPE`: `ServiceToken`)](#service-account--oauth-client-credentials-_jc_auth_type-servicetoken)
 - [Multiple organizations](#multiple-organizations)
 - [Deploying the Application](#deploying-the-application)
 - [Manual Testing \& Historical Backfill](#manual-testing--historical-backfill)
-  - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console)
-  - [Option 2: Using the gcloud CLI](#option-2-using-the-gcloud-cli)
+    - [Option 1: Using the Google Cloud Console](#option-1-using-the-google-cloud-console)
+    - [Option 2: Using the gcloud CLI](#option-2-using-the-gcloud-cli)
 - [Pipeline Architecture \& Error Handling (DLQ)](#pipeline-architecture--error-handling-dlq)
   - [Dead Letter Queue (DLQ)](#dead-letter-queue-dlq)
   - [Redriving Failed Messages](#redriving-failed-messages)
@@ -95,6 +97,8 @@ gcloud services enable storage-component.googleapis.com
 gcloud services enable secretmanager.googleapis.com
 gcloud services enable cloudresourcemanager.googleapis.com
 gcloud services enable pubsub.googleapis.com
+gcloud services enable eventarc.googleapis.com
+gcloud services enable cloudfunctions.googleapis.com
 ```
 
 - Your GCP Project ID and Number. You can automatically fetch and set these as variables in your CLI so you won't need to manually insert them in the commands below. Run this block in your terminal:
@@ -122,10 +126,20 @@ gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJE
 gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM@cloudbuild.gserviceaccount.com --role=roles/resourcemanager.projectIamAdmin
 ```
 
-- You must assign roles to the compute developer service account to access the secrets manager
+- You must assign roles to the compute developer service account
 
 ```bash
-gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role roles/secretmanager.secretAccessor
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/iam.serviceAccountUser
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/secretmanager.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/storage.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/run.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/cloudbuild.builds.builder
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/cloudscheduler.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/secretmanager.secretAccessor
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/cloudfunctions.invoker
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/cloudfunctions.developer
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/pubsub.admin
+gcloud projects add-iam-policy-binding $PROJECTID --member=serviceAccount:$PROJECTNUM-compute@developer.gserviceaccount.com --role=roles/resourcemanager.projectIamAdmin
 ```
 
 - You must also assign roles to the App Engine service account `*@appspot.gserviceaccount.com`. This account serves as identity when accessing Cloud Storage and Secret Manager. [Function Identity](https://cloud.google.com/functions/docs/securing/function-identity#:~:text=Every%20function%20is%20associated%20with,as%20its%20runtime%20service%20account.)


### PR DESCRIPTION
## Issues
* [CUT-5113](https://jumpcloud.atlassian.net/browse/CUT-5113) - CUT-5113

## What does this solve?
- This PR introduces support for JC Service Account authentication and Enterprise MultiOrg for the AWS Directory Insights Serverless App.
- Added support for manually testing using start and end time
- Added missing GCP permission docs

## Is there anything particularly tricky?
Enterprise multi org client and secret keys. I do not have access to enterprise org.
## How should this be tested?
1. API Key Test:

Package and deploy the app passing a standard API Key and setting JcAuthType="APIKey".

Verify the cron schedule successfully pulls data into the S3 bucket.

2. Test Service Account Auth (ServiceToken) and Multi Org:

Generate a Service Account token in the Enterprise JumpCloud console.

Update your AWS Secret to the secretID:secretToken format.

Update the CloudFormation stack, setting OrganizationID="ORG1,ORG2".

Update the CloudFormation stack, setting JcAuthType="ServiceToken".

Verify the Lambda successfully authenticates, pulls data, and uploads to S3.

3. Test Manual Execution:

Open the Orchestrator Lambda in the AWS Console.

In the Test tab, trigger it with a custom payload: {"start_time": "now-30d", "end_time": "now", "service": "directory"}.

Verify the Orchestrator and Worker function logs ran properly. Check the S3 for the files as well
<img width="1366" height="609" alt="image" src="https://github.com/user-attachments/assets/d3b007ce-380e-43d2-8172-5e55f0d1afab" />

## Screenshots
<img width="1115" height="301" alt="image" src="https://github.com/user-attachments/assets/83d9c6a0-4a7f-4fec-a374-592df7cfc118" />
<img width="1200" height="161" alt="image" src="https://github.com/user-attachments/assets/16aba5bc-5c77-488d-a783-50e3ab4c6594" />
<img width="1378" height="148" alt="image" src="https://github.com/user-attachments/assets/ca366504-e2be-4fab-8ad0-c7d60c808c61" />



[CUT-5113]: https://jumpcloud.atlassian.net/browse/CUT-5113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new OAuth-based authentication path and multi-tenant org selection that changes how requests are authorized and how work is partitioned, increasing the chance of misconfiguration or tenant-scoping bugs. Also changes output naming and orchestrator behavior, which could affect downstream ingestion if assumptions about file names or scheduling differ.
> 
> **Overview**
> **AWS Directory Insights v3.1.0 adds Service Account (OAuth) auth, multi-org ingestion, and manual backfill support.** The Lambda code now supports `JcAuthType=ServiceToken` (client credentials exchange to bearer token) in addition to API keys, and the orchestrator can iterate over multiple org IDs (optionally loaded from a Secrets Manager secret), enqueueing SQS jobs with an `org_id` for the worker.
> 
> The orchestrator now optionally accepts `start_time`/`end_time` (including `now` / `now-<n><unit>` parsing) and an event `service` override for manual testing, and `MaxEventsPerWorker` becomes a deploy-time parameter instead of a hardcoded constant. The worker writes per-org object keys (`jc_directoryinsights_<orgId>_<service>_<start>_<end>.json.gz`) to avoid overwrites and masks org IDs in logs.
> 
> Template/docs are updated accordingly: `serverless.yaml` adds `JcAuthType`, `JcMultiOrg`, and `MaxEventsPerWorker`, bumps `SemanticVersion` to `3.1.0`, and expands IAM to allow `secretsmanager:GetSecretValue` for the orchestrator; AWS/GCP READMEs and AWS changelog document multi-org, ServiceToken auth, manual window testing, and missing GCP permission steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6c4a616ba845642a6e87381c33756d0b6d2afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->