### PR TITLE
feat: Add EU/IN/STANDARD region support for Directory Insights API ba…

### DIFF
--- a/AWS/DirectoryInsights/CHANGELOG.md
+++ b/AWS/DirectoryInsights/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.2.0] - 2026-04-28
+
+### Added
+- New `JcRegion` parameter in `serverless.yaml` to support multi-region JumpCloud API deployments (`STANDARD`, `EU`, `IN`).
+- `get_jc_base_url()` helper function in `get-jcdirectoryinsights.py` that resolves the correct API base URL based on the `JcRegion` environment variable.
+
+### Changed
+- Orchestrator and Worker functions now use a dynamic base URL (`api.jumpcloud.com`, `api.eu.jumpcloud.com`, or `api.in.jumpcloud.com`) instead of a hardcoded value.
+
 ## [3.1.0] - 2026-03-20
 
 ### Added

--- a/AWS/DirectoryInsights/get-jcdirectoryinsights.py
+++ b/AWS/DirectoryInsights/get-jcdirectoryinsights.py
@@ -33,7 +33,25 @@ def get_secret(secret_id, suppress_error=False):
 JC_AUTH_TYPE_API_KEY = "APIKey"
 JC_AUTH_TYPE_SERVICE_TOKEN = "ServiceToken"
 JC_OAUTH_TOKEN_URL = "https://admin-oauth.id.jumpcloud.com/oauth2/token"
-JC_USER_AGENT = "JumpCloud_AWSServerless.DirectoryInsights/3.1.0"
+JC_USER_AGENT = "JumpCloud_AWSServerless.DirectoryInsights/3.2.0"
+
+JC_REGION_URL_MAP = {
+    "EU": "https://api.eu.jumpcloud.com",
+    "IN": "https://api.in.jumpcloud.com",
+    "STANDARD": "https://api.jumpcloud.com",
+}
+
+def get_jc_base_url():
+    """
+    Returns the JumpCloud API base URL based on the JcRegion environment variable.
+    Defaults to STANDARD (api.jumpcloud.com) if not set or unrecognized.
+    """
+    region = os.environ.get("JcRegion", "STANDARD").strip().upper() 
+    base_url = JC_REGION_URL_MAP.get(region)
+    if base_url is None:
+        logger.warning(f"Unrecognized JcRegion value '{region}'. Falling back to STANDARD.")
+        base_url = JC_REGION_URL_MAP["STANDARD"]
+    return base_url
 
 def _normalize_jc_auth_type(value):
     if value is None or str(value).strip() == "":
@@ -288,7 +306,8 @@ def jc_orchestrator(event, context):
             start_iso = previousTime.isoformat("T").replace("+00:00", "Z")
             end_iso = now.isoformat("T").replace("+00:00", "Z")
             
-            count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
+            base_url = get_jc_base_url()
+            count_url = f"{base_url}/insights/directory/v1/events/count"
             count_body = {'service': [service], 'start_time': start_iso, 'end_time': end_iso}
             
             try:
@@ -360,7 +379,8 @@ def jc_worker(event, context):
             logger.error(str(e))
             raise Exception(e)
 
-        url = "https://api.jumpcloud.com/insights/directory/v1/events"
+        base_url = get_jc_base_url()
+        url = f"{base_url}/insights/directory/v1/events"
         body = {
             'service': [service],
             'start_time': startDate,

--- a/AWS/DirectoryInsights/serverless.yaml
+++ b/AWS/DirectoryInsights/serverless.yaml
@@ -44,13 +44,21 @@ Parameters:
     Type: Number
     Default: 25000
     Description: 'Maximum number of events a single worker will process before the orchestrator chunks the time window.'
+  JcRegion:
+    Type: String
+    AllowedValues:
+      - STANDARD
+      - EU
+      - IN
+    Default: STANDARD
+    Description: 'Deployment region for JumpCloud API. STANDARD uses api.jumpcloud.com, EU uses api.eu.jumpcloud.com, IN uses api.in.jumpcloud.com.'
 
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: JumpCloud-DirectoryInsights
     Description: This Serverless Application can be used to collect your JumpCloud Directory Insights data at a regular interval.
     Author: JumpCloud Solutions Architecture
-    SemanticVersion: 3.1.0
+    SemanticVersion: 3.2.0
     HomePageUrl: https://git.io/JJlrZ
     SourceCodeUrl: https://git.io/JJiMo
     LicenseUrl: LICENSE
@@ -175,6 +183,7 @@ Resources:
           OrgId: !Sub ${OrganizationID}
           JcMultiOrg: !Ref JcMultiOrg
           MaxEventsPerWorker: !Ref MaxEventsPerWorker
+          JcRegion: !Ref JcRegion
       Events:
         ScheduleDirectoryInsightsTrigger:
           Type: Schedule
@@ -228,6 +237,7 @@ Resources:
           JcAuthType: !Ref JcAuthType
           BucketName: !Ref DirectoryInsightsBucket
           JsonFormat: !Sub ${JsonFormat}
+          JcRegion: !Ref JcRegion
       Events:
         SQSTrigger:
           Type: SQS


### PR DESCRIPTION
## Issues
* [CUT-5120](https://jumpcloud.atlassian.net/browse/CUT-5120) - Add EU/IN/STANDARD region support for AWS Directory Insights serverless app

## What does this solve?
The API base URL (`api.jumpcloud.com`) was hardcoded in the Python script, making it impossible to deploy the serverless app for customers in EU or IN regions. This PR adds a `JcRegion` parameter to `serverless.yaml` so users can choose their deployment region, and updates the script to resolve the correct base URL dynamically.

## Is there anything particularly tricky?
No major complexity. The `JcRegion` env var is passed to both Lambda functions (Orchestrator and Worker) since both make direct API calls to JumpCloud. A fallback to `STANDARD` is in place if the value is missing or unrecognized.

## How should this be tested?
1. Deploy with `JcRegion=STANDARD` — confirm requests hit `api.jumpcloud.com`
2. Deploy with `JcRegion=EU` — confirm requests hit `api.eu.jumpcloud.com`
3. Deploy with `JcRegion=IN` — confirm requests hit `api.in.jumpcloud.com`
4. Confirm that omitting `JcRegion` defaults to `STANDARD` behavior (no breaking change)

[CUT-5120]: https://jumpcloud.atlassian.net/browse/CUT-5120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to selecting the JumpCloud API base URL via a new env/CloudFormation parameter; behavior remains unchanged when `JcRegion` is unset or `STANDARD`.
> 
> **Overview**
> Adds multi-region support for Directory Insights by introducing a `JcRegion` parameter (passed to both Orchestrator and Worker Lambdas) and a `get_jc_base_url()` helper that maps `STANDARD`/`EU`/`IN` to the correct JumpCloud API host with a safe fallback to `STANDARD`.
> 
> Updates the Orchestrator and Worker API calls to build `/insights/directory/v1/events` and `/events/count` URLs from this dynamic base URL, and bumps the app version to `3.2.0` (user-agent, SAM `SemanticVersion`, and changelog).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf0b99832057a9ee67107b6f6be1062ee28cde8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->