### PR TITLE
CUT-5120: GCP region variable

### DIFF
--- a/GCP/DirectoryInsights/CHANGELOG.md
+++ b/GCP/DirectoryInsights/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.1] - 2026-04-30
+
+### Added
+
+- Added support for base url region (EU, IN)
+
 ## [3.1.0] - 2026-04-08
 
 ### Added

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -6,6 +6,12 @@ substitutions:
   _JC_ORG_ID: "CHANGEVALUE"
   # true = treat _JC_ORG_ID / org secret as comma-separated org list (e.g. "org1,org2"); false = one org id (entire string) (default).
   _JC_MULTI_ORG: "false"
+
+  # Optional override for JumpCloud API base URL (e.g. for private regions or testing against a proxy)
+  _JC_BASE_URL: "https://api.jumpcloud.com"
+  # _JC_BASE_URL: "https://api.eu.jumpcloud.com" # EU region override
+  # _JC_BASE_URL: "https://api.in.jumpcloud.com" # IN region override
+
   _JC_SERVICE: "CHANGEVALUE" # Can accept multiple values' for example:  _JC_SERVICE: directory,systems or gather logs from all services with the _JC_SERVICE: all. Available services:
   ### all, access_management, alerts, asset_management, directory, ldap, mdm, notifications, object_storage, password_manager, radius, reports, saas_app_management, software, sso, systems, workflows. ###
   # Prefix for GCS bucket, secrets, functions, Pub/Sub, and scheduler.

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -98,7 +98,7 @@ steps:
       - --region=$_REGION_LOCATION
       - --source=.
       - --runtime=python312
-      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,max_events_per_worker=$_MAX_EVENTS_PER_WORKER,jc_auth_type=$_JC_AUTH_TYPE,jc_multi_org=$_JC_MULTI_ORG
+      - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,max_events_per_worker=$_MAX_EVENTS_PER_WORKER,jc_auth_type=$_JC_AUTH_TYPE,jc_multi_org=$_JC_MULTI_ORG,jc_base_url=$_JC_BASE_URL
       - --entry-point=jc_orchestrator
       - --trigger-http
       - --no-allow-unauthenticated
@@ -115,7 +115,7 @@ steps:
           --region=$_REGION_LOCATION \
           --source=. \
           --runtime=python312 \
-          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,bucket_name=${_RESOURCE_PREFIX}-di-bucket,json_format=$_JSON_FORMAT,jc_auth_type=$_JC_AUTH_TYPE,jc_multi_org=$_JC_MULTI_ORG \
+          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_base_url=$_JC_BASE_URL,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,bucket_name=${_RESOURCE_PREFIX}-di-bucket,json_format=$_JSON_FORMAT,jc_auth_type=$_JC_AUTH_TYPE,jc_multi_org=$_JC_MULTI_ORG \
           --entry-point=jc_worker \
           --memory=$_WORKER_MEMORY \
           --trigger-topic=${_RESOURCE_PREFIX}-jobs \
@@ -159,7 +159,7 @@ steps:
           --region=$_REGION_LOCATION \
           --source=. \
           --runtime=python312 \
-          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,dlq_sub_id=${_RESOURCE_PREFIX}-jobs-dlq-sub,main_topic_id=${_RESOURCE_PREFIX}-jobs \
+          --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,dlq_sub_id=${_RESOURCE_PREFIX}-jobs-dlq-sub,jc_base_url=$_JC_BASE_URL,main_topic_id=${_RESOURCE_PREFIX}-jobs \
           --entry-point=redrive_dlq \
           --trigger-http \
           --no-allow-unauthenticated \

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -60,7 +60,14 @@ JC_AUTH_TYPE_API_KEY = "APIKey"
 JC_AUTH_TYPE_SERVICE_TOKEN = "ServiceToken"
 JC_OAUTH_TOKEN_URL = "https://admin-oauth.id.jumpcloud.com/oauth2/token"
 JC_USER_AGENT = "JumpCloud_GCPServerless.DirectoryInsights/3.1.0"
+JC_API_BASE_URL = os.environ.get("jc_base_url", "https://api.jumpcloud.com")
 
+# Check if is empty
+if JC_API_BASE_URL is None or str(JC_API_BASE_URL).strip() == "":
+    raise Exception("Environment variable jc_base_url is empty. Please set it to the appropriate JumpCloud API base URL (e.g. https://api.jumpcloud.com for US, https://api.eu.jumpcloud.com for EU, or https://api.in.jumpcloud.com for IN).")
+
+if JC_API_BASE_URL.endswith("/"):
+    JC_API_BASE_URL = JC_API_BASE_URL[:-1]
 
 def _normalize_jc_auth_type(value):
     if value is None or str(value).strip() == "":
@@ -378,7 +385,7 @@ def jc_orchestrator(request):
             start_iso = window_start.isoformat("T").replace("+00:00", "Z")
             end_iso = window_end.isoformat("T").replace("+00:00", "Z")
 
-            count_url = "https://api.jumpcloud.com/insights/directory/v1/events/count"
+            count_url = f"{JC_API_BASE_URL}/insights/directory/v1/events/count"
 
             count_body = {'service': [service], 'start_time': start_iso, 'end_time': end_iso}
 
@@ -485,7 +492,7 @@ def jc_worker(event, context):
     start_date = payload['start_time']
     end_date = payload['end_time']
     
-    url = "https://api.jumpcloud.com/insights/directory/v1/events"
+    url = f"{JC_API_BASE_URL}/insights/directory/v1/events"
     body = {
         'service': [service],
         'start_time': start_date,

--- a/GCP/DirectoryInsights/main.py
+++ b/GCP/DirectoryInsights/main.py
@@ -59,7 +59,7 @@ def get_secret(project_id, secret_name):
 JC_AUTH_TYPE_API_KEY = "APIKey"
 JC_AUTH_TYPE_SERVICE_TOKEN = "ServiceToken"
 JC_OAUTH_TOKEN_URL = "https://admin-oauth.id.jumpcloud.com/oauth2/token"
-JC_USER_AGENT = "JumpCloud_GCPServerless.DirectoryInsights/3.1.0"
+JC_USER_AGENT = "JumpCloud_GCPServerless.DirectoryInsights/3.1.1"
 JC_API_BASE_URL = os.environ.get("jc_base_url", "https://api.jumpcloud.com")
 
 # Check if is empty


### PR DESCRIPTION
## Issues
* [CUT-5120](https://jumpcloud.atlassian.net/jira/software/c/projects/CUT/boards/147?selectedIssue=CUT-5121) 

## What does this solve?
Adds the `jc_base_url` env var to change between regions on cloudbuild.

## Is there anything particularly tricky?
Need some API services enabled:
```
gcloud services enable \
  cloudbuild.googleapis.com \
  cloudfunctions.googleapis.com \
  pubsub.googleapis.com \
  secretmanager.googleapis.com \
  cloudscheduler.googleapis.com \
  run.googleapis.com
```

## How should this be tested?
Auth the GCP env: `gcloud auth login`
Set Project ID: `gcloud config set project YOUR_PROJECT_ID`

Then submit the .yaml file
```
gcloud builds submit --config=cloudbuild.yaml . \
  --substitutions=\
_JC_API_KEY="your-jumpcloud-api-key",\
_JC_ORG_ID="your-jumpcloud-org-id",\
_JC_SERVICE="all",\
_GCP_PROJECT_ID_NAME="your-gcp-project-id",\
_SCHEDULE_CRON_TIME="0 * * * *",\
_JSON_FORMAT="NDJson",\
_STORAGE_CLASS="standard",\
_REGION_LOCATION="us-central1"
```

[CUT-5120]: https://jumpcloud.atlassian.net/browse/CUT-5120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the base URL used for all JumpCloud Insights API calls and introduces startup validation that can fail deployments if the env var is mis-set or empty.
> 
> **Overview**
> Adds support for targeting different JumpCloud API regions by introducing a configurable `jc_base_url`/`_JC_BASE_URL` and updating Insights `count` and `events` requests to build URLs from this base.
> 
> Adds validation/normalization for the base URL (non-empty, trims trailing slash) and documents the new option in `cloudbuild.yaml` and the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18cf1279f5b8a724eeea5bcf93ed1fb24dd315c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->