### PR TITLE
Update GCP Python and Requirements Version

### DIFF
--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -102,6 +102,7 @@ steps:
       - --entry-point=jc_orchestrator
       - --trigger-http
       - --no-allow-unauthenticated
+      - --ingress-settings=internal-only
       - --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
 
   # Deploy the Worker Cloud Function & Configure DLQ
@@ -121,6 +122,7 @@ steps:
           --trigger-topic=${_RESOURCE_PREFIX}-jobs \
           --retry \
           --no-allow-unauthenticated \
+          --ingress-settings=internal-only \
           --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
 
         # 2. Get the auto-generated Pub/Sub Subscription
@@ -163,6 +165,7 @@ steps:
           --entry-point=redrive_dlq \
           --trigger-http \
           --no-allow-unauthenticated \
+          --ingress-settings=internal-only \
           --run-service-account=$_GCP_PROJECT_ID_NAME@appspot.gserviceaccount.com
 
         # 2. Grant the service account permission to PULL from the DLQ subscription

--- a/GCP/DirectoryInsights/cloudbuild.yaml
+++ b/GCP/DirectoryInsights/cloudbuild.yaml
@@ -97,7 +97,7 @@ steps:
       - ${_RESOURCE_PREFIX}-orchestrator
       - --region=$_REGION_LOCATION
       - --source=.
-      - --runtime=python312
+      - --runtime=python314
       - --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,cron_schedule=$_SCHEDULE_CRON_TIME,service=$_JC_SERVICE,pubsub_topic=${_RESOURCE_PREFIX}-jobs,max_events_per_worker=$_MAX_EVENTS_PER_WORKER,jc_auth_type=$_JC_AUTH_TYPE,jc_multi_org=$_JC_MULTI_ORG,jc_base_url=$_JC_BASE_URL
       - --entry-point=jc_orchestrator
       - --trigger-http
@@ -114,7 +114,7 @@ steps:
         gcloud functions deploy ${_RESOURCE_PREFIX}-worker \
           --region=$_REGION_LOCATION \
           --source=. \
-          --runtime=python312 \
+          --runtime=python314 \
           --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,jc_base_url=$_JC_BASE_URL,jc_api_key_secret=${_RESOURCE_PREFIX}-api-key,jc_org_id=${_RESOURCE_PREFIX}-org-id,bucket_name=${_RESOURCE_PREFIX}-di-bucket,json_format=$_JSON_FORMAT,jc_auth_type=$_JC_AUTH_TYPE,jc_multi_org=$_JC_MULTI_ORG \
           --entry-point=jc_worker \
           --memory=$_WORKER_MEMORY \
@@ -158,7 +158,7 @@ steps:
         gcloud functions deploy ${_RESOURCE_PREFIX}-redrive \
           --region=$_REGION_LOCATION \
           --source=. \
-          --runtime=python312 \
+          --runtime=python314 \
           --set-env-vars=gcp_project_id=$_GCP_PROJECT_ID_NAME,dlq_sub_id=${_RESOURCE_PREFIX}-jobs-dlq-sub,jc_base_url=$_JC_BASE_URL,main_topic_id=${_RESOURCE_PREFIX}-jobs \
           --entry-point=redrive_dlq \
           --trigger-http \

--- a/GCP/DirectoryInsights/requirements.txt
+++ b/GCP/DirectoryInsights/requirements.txt
@@ -4,3 +4,4 @@ google-cloud-secret-manager>=2.20.0
 google-cloud-pubsub>=2.21.0
 google-cloud-storage>=2.16.0
 functions-framework>=3.5.0
+gunicorn>=22.0.0

--- a/GCP/DirectoryInsights/requirements.txt
+++ b/GCP/DirectoryInsights/requirements.txt
@@ -1,6 +1,6 @@
-requests==2.31.0
-croniter==2.0.1
-google-cloud-secret-manager==2.16.2
-google-cloud-pubsub==2.18.4
-google-cloud-storage==2.13.0
-functions-framework==3.4.0
+requests>=2.32.0
+croniter>=3.0.0
+google-cloud-secret-manager>=2.20.0
+google-cloud-pubsub>=2.21.0
+google-cloud-storage>=2.16.0
+functions-framework>=3.5.0


### PR DESCRIPTION
## Issues
* [CUT-5210](https://jumpcloud.atlassian.net/browse/CUT-5210) - CUT-5210

## What does this solve?
Updates Python 3.12->3.14 to address vulnerabilities. Also updated and tested required packages/dependencies in Requirements.txt
## Is there anything particularly tricky?
N/A
## How should this be tested?
Deploy the new GCP serverless version. Validate that the Orchestrator and Worker is running properly with the updated versions.

## Screenshots
<img width="775" height="379" alt="image" src="https://github.com/user-attachments/assets/dec41225-9488-45e7-bc11-da28907fb23c" />
<img width="927" height="414" alt="image" src="https://github.com/user-attachments/assets/928becf4-1b84-4dd6-aed8-842bd7ad5a88" />
<img width="740" height="276" alt="image" src="https://github.com/user-attachments/assets/408f3a1b-38c7-4d45-8174-a44e5966a096" />


[CUT-5210]: https://jumpcloud.atlassian.net/browse/CUT-5210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runtime and dependency upgrades across all serverless entrypoints can change behavior at deploy time; internal-only ingress may break any existing public or out-of-VPC HTTP callers to orchestrator/redrive unless they were already internal.
> 
> **Overview**
> Bumps **GCP Cloud Functions** deploys for the orchestrator, worker, and redrive from **Python 3.12** to **Python 3.14**, and sets **`--ingress-settings=internal-only`** on all three so HTTP endpoints are not reachable from the public internet (scheduler/OIDC and in-project callers remain the intended paths).
> 
> **`requirements.txt`** moves from pinned versions to **minimum floors** (`>=`) on JumpCloud/Google client libraries and **`functions-framework`**, and adds **`gunicorn>=22.0.0`** for the updated runtime stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33eeebfc82ec0803c912502970253982f48d3456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the deployment environment for multiple cloud functions to use a newer Python runtime.
  * Relaxed dependency version constraints to minimum-version requirements to support newer compatible releases.
  * Added Gunicorn to the dependency list for improved runtime alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->